### PR TITLE
MOD : short input width

### DIFF
--- a/src/core/elements/_input.less
+++ b/src/core/elements/_input.less
@@ -155,7 +155,7 @@ textarea.lui.input {
 
 // Inputs length (horizontal sizing)
 // =====
-.lui.input.short { width: 8em; }
+.lui.input.short { width: 9em; }
 .lui.input.medium { width: 15em; }
 .lui.input.long { width: 20em; }
 .lui.input.x-long { width: 25em; }


### PR DESCRIPTION
Allows to set a datepicker as "short" without croping the date