### PR TITLE
grunt [enh] splitted the gruntfile in 9 files for better readability

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,160 +1,26 @@
 module.exports = function(grunt) {
-    grunt.initConfig({
-        pkg: grunt.file.readJSON('package.json'),
-        jshint: {
-            files: ['js/**/*.js'],
-            options: {
-                // options here to override JSHint defaults
-                globals: {
-                    jQuery: true,
-                    console: true,
-                    module: true,
-                    document: true
-                }
-            }
-        },
-        karma: {
-            options: {
-                configFile: 'karma.conf.js'
-            },
-            dev: {
-            },
-            continuous: {
-                singleRun: true,
-                autoWatch: false,
-                browsers: ['PhantomJS'],
-                reporters: ['progress']
-            },
-            coverage: {
-                singleRun: true,
-                autoWatch: false,
-                browsers: ['PhantomJS'],
-                reporters: ['coverage'],
-                preprocessors: {
-                    'test/**/*.js': ['coverage'],
-                }
-            },
-            ng12:{
-                configFile: 'karma.ng12.js',
-                singleRun: true,
-                autoWatch: false,
-                browsers: ['PhantomJS'],
-                reporters: ['progress']
-            }
-        },
-        protractor: {
-            options: {
-                configFile: "protractor.conf.js", // Default config file
-                keepAlive: false, // If false, the grunt process stops when the test fails.
-                noColor: false, // If true, protractor will not use colors in its output.
-                args: {
-                    specs: [
-                        'tests/e2e/**/*.spec.js'
-                ],
-                    capabilities: {
-                        'browserName': 'chrome' 
-                    },
-                    rootElement: '[ng-app]'
-                }
-            },
-            continuous: {
-            },
-            dev: {
-                configFile: "protractor.conf.js"
-            }
-        },
-        watch: {
-            less: {
-                files: ['src/**/*.less'],
-                tasks: ['less'],
-                options: {
-                    nospawn: true
-                }
-            },
-            js: {
-                files: ['js/**/*.js'],
-                tasks: ['minifyjs','jshint'], // minify is put before jshint because if jshint finds an error, it will not launch any tasks after that so the minification was not done
-                options: {
-                    nospawn: true
-                }
-            }
-        },
-        concat: {
-            options: {
-                // define a string to put between each file in the concatenated output
-                separator: ';'
-            },
-            dist: {
-                // we dont use the **/*.js synthax cuz it's still a WIP in the transition and all the js files are not meant to be distributed
-                src: [
-                    'js/lui.js',
-                    'js/directives/*.js',
-                    'js/directives/lucca/*.js',
-                    'js/filters/*.js',
-                ],
-                // the location of the resulting JS file
-                dest: 'dist/lucca-ui.js'
-            },
-            ng12:{
-                src:[
-                    'js/lui.js',
-                    'js/directives/percentage-picker.js',
-                    'js/directives/timespan-picker.js',
-                    'js/filters/*.js',
-                ],
-                dest: 'dist/custom/lucca-ui-compat-ng-1-2.js'
-            }
-        },
-        uglify: {
-            options: {
-            // the banner is inserted at the top of the output
-                banner: '/*! lucca-ui <%= grunt.template.today("dd-mm-yyyy") %> */\n'
-            },
-            dist: {
-                files: {
-                    'dist/lucca-ui.min.js': ['<%= concat.dist.dest %>']
-                }
-            }
-        },
-        less: {
-            development: {
-                options: {
-                    compress: true,
-                    relativeUrls:true,
-                    sourceMap:true,
-                    sourceMapFileInline:true,
-                    sourceMapRootpath:"..",
-                    optimization: 2
-                },
-                files: [
-                    {
-                        "dist/lucca-ui.min.css": "src/lucca-ui.dist.less",
-                        "demo/demo.min.css": "demo/less/demo.less"
-                    }
-                ]
-            }
-        },
-        concurrent: {
-            options: {
-                logConcurrentOutput: true
-            },
-            dev: ['watch','karma']
-        }
-    });
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.loadNpmTasks('grunt-karma');
-    grunt.loadNpmTasks('grunt-protractor-runner');
 
-    grunt.loadNpmTasks('grunt-concurrent'); // loads concurrent runner
+	grunt.initConfig({
+		pkg: grunt.file.readJSON('package.json'),
+	});
 
-    grunt.loadNpmTasks('grunt-contrib-watch'); // loads watch contrib
-
-    grunt.loadNpmTasks('grunt-contrib-less'); // loads less compiler
-    grunt.loadNpmTasks('grunt-contrib-concat'); // loads the file concatener
-    grunt.loadNpmTasks('grunt-contrib-uglify'); // loads the file minifier
-    
-    grunt.registerTask('minifyjs', ['concat:dist','uglify']);
-    grunt.registerTask('default', ['concurrent']);
-    grunt.registerTask('ng12', ['concat:ng12','karma:ng12']);
+	// Loads the different modules used by this gruntfile
+	grunt.loadNpmTasks('grunt-contrib-jshint');
+	grunt.loadNpmTasks('grunt-karma');
+	grunt.loadNpmTasks('grunt-protractor-runner');
+	grunt.loadNpmTasks('grunt-concurrent'); // loads concurrent runner
+	grunt.loadNpmTasks('grunt-contrib-watch'); // loads watch contrib
+	grunt.loadNpmTasks('grunt-contrib-less'); // loads less compiler
+	grunt.loadNpmTasks('grunt-contrib-concat'); // loads the file concatener
+	grunt.loadNpmTasks('grunt-contrib-uglify'); // loads the file minifier
+	
+	// load the configs of all tasks defined under /config
+	var configs = require('load-grunt-configs')(grunt);
+	grunt.initConfig(configs);
+	
+	// register some grunt tasks
+	grunt.registerTask('default', ['concurrent']);
+	grunt.registerTask('minifyjs', ['concat:dist','uglify']);
+	grunt.registerTask('ng12', ['concat:ng12','karma:ng12']);
 
 };

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,3 @@
+All dem config file for grunt.
+
+i used this [post](https://creynders.wordpress.com/2014/02/10/best-way-to-handle-large-grunt-files/) for splitting mah gruntfile

--- a/config/concat.js
+++ b/config/concat.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = function(grunt, options){
+	return {
+		options: {
+			// define a string to put between each file in the concatenated output
+			separator: ';'
+		},
+		dist: {
+			// we dont use the **/*.js synthax cuz it's still a WIP in the transition and all the js files are not meant to be distributed
+			src: [
+				'js/lui.js',
+				'js/directives/*.js',
+				'js/directives/lucca/*.js',
+				'js/filters/*.js',
+			],
+			// the location of the resulting JS file
+			dest: 'dist/lucca-ui.js'
+		},
+		ng12:{
+			src:[
+				'js/lui.js',
+				'js/directives/percentage-picker.js',
+				'js/directives/timespan-picker.js',
+				'js/filters/*.js',
+			],
+			dest: 'dist/custom/lucca-ui-compat-ng-1-2.js'
+		}
+	};
+}

--- a/config/concurrent.js
+++ b/config/concurrent.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = function(grunt, options){
+	return {
+		options: {
+			logConcurrentOutput: true
+		},
+		dev: ['watch','karma']
+	};
+};

--- a/config/jshint.js
+++ b/config/jshint.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function(grunt, options){
+	return {
+		files: ['js/**/*.js'],
+		options: {
+			// options here to override JSHint defaults
+			globals: {
+				jQuery: true,
+				console: true,
+				module: true,
+				document: true
+			}
+		}
+	};
+}

--- a/config/karma.js
+++ b/config/karma.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = function(grunt, options){
+	return {
+		options: {
+			configFile: 'karma.conf.js'
+		},
+		dev: {
+		},
+		continuous: {
+			singleRun: true,
+			autoWatch: false,
+			browsers: ['PhantomJS'],
+			reporters: ['progress']
+		},
+		coverage: {
+			singleRun: true,
+			autoWatch: false,
+			browsers: ['PhantomJS'],
+			reporters: ['coverage'],
+			preprocessors: {
+				'test/**/*.js': ['coverage'],
+			}
+		},
+		ng12:{
+			configFile: 'karma.ng12.js',
+			singleRun: true,
+			autoWatch: false,
+			browsers: ['PhantomJS'],
+			reporters: ['progress']
+		}
+	};
+}

--- a/config/less.js
+++ b/config/less.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = function(grunt, options){
+	return {
+		less: {
+			development: {
+				options: {
+					compress: true,
+					relativeUrls:true,
+					sourceMap:true,
+					sourceMapFileInline:true,
+					sourceMapRootpath:"..",
+					optimization: 2
+				},
+				files: [{
+					"dist/lucca-ui.min.css": "src/lucca-ui.dist.less",
+					"demo/demo.min.css": "demo/less/demo.less"
+				}]
+			}
+		},
+	};
+}

--- a/config/protractor.js
+++ b/config/protractor.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = function(grunt, options){
+	return {
+		options: {
+			configFile: "protractor.conf.js", // Default config file
+			keepAlive: false, // If false, the grunt process stops when the test fails.
+			noColor: false, // If true, protractor will not use colors in its output.
+			args: {
+				specs: [
+					'tests/e2e/**/*.spec.js'
+				],
+				capabilities: {
+					'browserName': 'chrome' 
+				},
+				rootElement: '[ng-app]'
+			}
+		},
+		continuous: {
+		},
+		dev: {
+			configFile: "protractor.conf.js"
+		}
+	};
+}

--- a/config/uglify.js
+++ b/config/uglify.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function(grunt, options){
+	return {
+		options: {
+			// the banner is inserted at the top of the output
+			banner: '/*! lucca-ui <%= grunt.template.today("dd-mm-yyyy") %> */\n'
+		},
+		dist: {
+			files: {
+				'dist/lucca-ui.min.js': ['<%= concat.dist.dest %>']
+			}
+		}
+	};
+}

--- a/config/watch.js
+++ b/config/watch.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function(grunt, options){
+	return {
+		less: {
+			files: ['src/**/*.less'],
+			tasks: ['less'],
+			options: {
+				nospawn: true
+			}
+		},
+		js: {
+			files: ['js/**/*.js'],
+			tasks: ['minifyjs','jshint'], // minify is put before jshint because if jshint finds an error, it will not launch any tasks after that so the minification was not done
+			options: {
+				nospawn: true
+			}
+		}
+	};
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "karma-jasmine": "^0.3.6",
     "karma-junit-reporter": "^0.2.2",
     "karma-ng-html2js-preprocessor": "^0.1.0",
-    "karma-phantomjs-launcher": "^0.1.4"
+    "karma-phantomjs-launcher": "^0.1.4",
+    "load-grunt-configs": "^0.4.3"
   },
   "author": "Lucca",
   "license": "ISC",


### PR DESCRIPTION
the `gruntfile.js` was getting too big so i splitted it in the folder `/config`

each file in `/config` defines a task, ex: `jshint` or `karma` and the `gruntfile.js` loads them and defines macro tasks like
```js
grunt.registerTask('minifyjs', ['concat:dist','uglify']);
```