### PR TITLE
Luid.user.picker [enh] selected-user attribute

### DIFF
--- a/demo/lucca-spe.html
+++ b/demo/lucca-spe.html
@@ -116,11 +116,11 @@
 				<b>Important:</b> your local website must implpement the api <code>/api/v3/users/find</code> for it to work. This feature is available on branch <a class="lui fancy link" href="https://github.com/LuccaSA/ilucca/tree/rc">rc</a> (since <a class="lui fancy link" href="https://github.com/LuccaSA/ilucca/pull/528#event-443784814">10/23/2015</a>) and <a class="lui fancy link" href="https://github.com/LuccaSA/ilucca/tree/master">master</a> (since 10/30/2015).
 			</p>
 			<p>
-				<luid-user-picker class="lui input" ng-model="myUser.selected" show-former-employees="isChecked"></luid-user-picker>
+				<luid-user-picker class="lui input" selected-user="myUser.selected1" show-former-employees="isChecked"></luid-user-picker>
 				<input type="checkbox" ng-model="isChecked">Show former employees
 			</p>
 			<p>
-				Selected user: <code>{{myUser.selected.firstName}} {{myUser.selected.lastName}}</code>
+				Selected user: <code>{{myUser.selected1.firstName}} {{myUser.selected1.lastName}}</code>
 			</p>
 			<hr />
 			<h5>Custom filtering</h5>
@@ -134,9 +134,9 @@
 			</p>
 			<p>
 				Set of users with the selected filter applied: 
-				<luid-user-picker ng-if="customFilter === 'hasShortName'" class="lui input" ng-model="myUser.selected" custom-filter="hasShortName"></luid-user-picker>
-				<luid-user-picker ng-if="customFilter === 'beginsWithConsonant'" class="lui input" ng-model="myUser.selected" custom-filter="beginsWithConsonant"></luid-user-picker>
-				<luid-user-picker ng-if="customFilter === 'nameContainsT'" class="lui input" ng-model="myUser.selected" custom-filter="nameContainsT"></luid-user-picker>
+				<luid-user-picker ng-if="customFilter === 'hasShortName'" class="lui input" selected-user="myUser.selected2" custom-filter="hasShortName"></luid-user-picker>
+				<luid-user-picker ng-if="customFilter === 'beginsWithConsonant'" class="lui input" selected-user="myUser.selected2" custom-filter="beginsWithConsonant"></luid-user-picker>
+				<luid-user-picker ng-if="customFilter === 'nameContainsT'" class="lui input" selected-user="myUser.selected2" custom-filter="nameContainsT"></luid-user-picker>
 			</p>
 		</div>
 		<div class="lui dashed divider">

--- a/js/directives/lucca/user-picker.js
+++ b/js/directives/lucca/user-picker.js
@@ -35,7 +35,7 @@
 	"<small ng-if=\"user.overflow\" translate translate-values=\"{cnt:user.cnt, all:user.all}\">{{user.overflow}}</small>" +
 	"</ui-select-choices>";
 
-	var userPickerTemplate = "<ui-select theme=\"bootstrap\"" +
+	var userPickerTemplate = "<ui-select ng-model=\"selectedUser\" theme=\"bootstrap\"" +
 	"class=\"lui regular nguibs-ui-select\" on-select=\"updateSelectedUser($select.selected)\" on-remove=\"onRemove()\" ng-disabled=\"controlDisabled\">" +
 	"<ui-select-match placeholder=\"{{ 'LUIDUSERPICKER_PLACEHOLDER' | translate }}\">{{ $select.selected.firstName }} {{$select.selected.lastName}}</ui-select-match>" +
 	uiSelectChoicesTemplate +
@@ -71,7 +71,9 @@
 				customFilter: "=", // should be a function with this signature: function(user){ return boolean; } 
 				/*** OPERATION SCOPE ***/
 				appId: "=", // id of the application that users should have access
-				operations: "=" // list of operation ids that users should have access
+				operations: "=", // list of operation ids that users should have access
+				/*** SELECTED USER ***/
+				selectedUser: "=", // variable in the ng-model of ui-select
 			},
 			link: function (scope, elt, attrs, ctrl) {
 				ctrl.isMultipleSelect = false;
@@ -553,9 +555,13 @@
 		/*********************/
 
 		$scope.updateSelectedUser = function(selectedUser) {
+			// Update the value of $scope.selectedUser
+			$scope.selectedUser = selectedUser;
+			// Update selectedUser in parent scope
+			// We need to do this before calling the onSelect function
+			// Otherwise, it will take the out dated value
+			$scope.$apply();
 			$scope.onSelect();
-			// Bind the selected user to the ng-model in luid-user-picker directive
-			$scope.ngModel = selectedUser;
 		};
 
 		// userPickerMultiple feature, not yet implemented

--- a/tests/e2e/e2e.html
+++ b/tests/e2e/e2e.html
@@ -92,13 +92,13 @@
 			<div ng-controller="luidUserPickerCtrl" class="lui block round">
 				<!-- Without former employees -->
 				<div>
-					<luid-user-picker id="luidUserPicker_myUser_select" ng-model="myUser.selected"></luid-user-picker>
+					<luid-user-picker id="luidUserPicker_myUser_select" selected-user="myUser.selected"></luid-user-picker>
 					<div id="luidUserPicker_myUser_value">{{myUser.selected.firstName}} {{myUser.selected.lastName}}
 					</div>
 				</div>
 				<!-- With former employees -->
 				<div>
-					<luid-user-picker id="luidUserPicker_myUser_select_former_employees" ng-model="myUser.selected" show-former-employees="true"></luid-user-picker>
+					<luid-user-picker id="luidUserPicker_myUser_select_former_employees" selected-user="myUser.selected" show-former-employees="true"></luid-user-picker>
 				</div>
 			</div>
 		</article>

--- a/tests/spec/directives/user-picker.spec.js
+++ b/tests/spec/directives/user-picker.spec.js
@@ -57,7 +57,8 @@ describe('luidUserPicker', function(){
 		var findApiWithoutClue = /api\/v3\/users\/find\?/;
 		var standardFilters = /formerEmployees=false\&limit=\d*/;
 		beforeEach(function(){
-			var tpl = angular.element('<luid-user-picker ng-model="myUser"></luid-user-picker>');
+			$scope.myUser = {};
+			var tpl = angular.element('<luid-user-picker selected-user="myUser"></luid-user-picker>');
 			elt = $compile(tpl)($scope);
 			isolateScope = elt.isolateScope();
 			$scope.$digest();
@@ -92,6 +93,19 @@ describe('luidUserPicker', function(){
 			expect(isolateScope.users[0].overflow).toEqual("LUIDUSERPICKER_ERR_GET_USERS");
 			expect(console.log).toHaveBeenCalled();
 		});
+		/***************************************/
+		/***** Bi-directional data binding *****/
+		/***************************************/
+		it('should update variable linked to selectedUser in parent scope', function() {
+			isolateScope.selectedUser = { id: 5, firstName: 'Lucien', lastName: 'Bertin' };
+			isolateScope.$apply();
+			expect($scope.myUser).toBe(isolateScope.selectedUser);
+		});
+		it('should update selectedUser in luid-user-picker scope', function() {
+			$scope.myUser = { id: 5, firstName: 'Lucien', lastName: 'Bertin' };
+			$scope.$digest();
+			expect(isolateScope.selectedUser).toBe($scope.myUser);
+		});
 	});
 
 	// TODO
@@ -100,7 +114,7 @@ describe('luidUserPicker', function(){
 	**********************/
 	describe("with pagination", function(){
 		beforeEach(function(){
-			var tpl = angular.element('<luid-user-picker ng-model="myUser"></luid-user-picker>');
+			var tpl = angular.element('<luid-user-picker selected-user="myUser"></luid-user-picker>');
 			elt = $compile(tpl)($scope);
 			isolateScope = elt.isolateScope();
 			$scope.$digest();
@@ -193,7 +207,7 @@ describe('luidUserPicker', function(){
 		var findApiWithClue = /api\/v3\/users\/find\?clue=/;
 		var standardFilters = /\&formerEmployees=true\&limit=\d*/;
 		beforeEach(function(){
-			var tpl = angular.element('<luid-user-picker ng-model="myUser" show-former-employees="showFE"></luid-user-picker>');
+			var tpl = angular.element('<luid-user-picker selected-user="myUser" show-former-employees="showFE"></luid-user-picker>');
 			$scope.showFE = true;
 			elt = $compile(tpl)($scope);
 			isolateScope = elt.isolateScope();
@@ -226,7 +240,7 @@ describe('luidUserPicker', function(){
 	**********************/
 	describe("with custom filtering", function(){
 		beforeEach(function(){
-			var tpl = angular.element('<luid-user-picker ng-model="myUser" custom-filter="customFilter"></luid-user-picker>');
+			var tpl = angular.element('<luid-user-picker selected-user="myUser" custom-filter="customFilter"></luid-user-picker>');
 			$scope.customFilter = function(user) { // only user with even id
 				return user.id % 2 === 0;
 			};
@@ -282,7 +296,7 @@ describe('luidUserPicker', function(){
 		beforeEach(function(){
 			$scope.ops = [1,2,3];
 			$scope.appId = 86;
-			var tpl = angular.element('<luid-user-picker ng-model="myUser" app-id="appId" operations="ops"></luid-user-picker>');
+			var tpl = angular.element('<luid-user-picker selected-user="myUser" app-id="appId" operations="ops"></luid-user-picker>');
 			elt = $compile(tpl)($scope);
 			isolateScope = elt.isolateScope();
 			$scope.$digest();
@@ -323,7 +337,7 @@ describe('luidUserPicker', function(){
 	/* BASIC CASE: 2 homonyms */
 	describe("with 2 homonyms", function(){
 		beforeEach(function(){
-			var tpl = angular.element('<luid-user-picker ng-model="myUser"></luid-user-picker>');
+			var tpl = angular.element('<luid-user-picker selected-user="myUser"></luid-user-picker>');
 			elt = $compile(tpl)($scope);
 			isolateScope = elt.isolateScope();
 			$scope.$digest();
@@ -394,7 +408,7 @@ describe('luidUserPicker', function(){
 	/* COMPLEX CASE: more than 2 homonyms */
 	describe("with 4 homonyms", function(){
 		beforeEach(function(){
-			var tpl = angular.element('<luid-user-picker ng-model="myUser"></luid-user-picker>');
+			var tpl = angular.element('<luid-user-picker selected-user="myUser"></luid-user-picker>');
 			elt = $compile(tpl)($scope);
 			isolateScope = elt.isolateScope();
 			$scope.$digest();
@@ -445,7 +459,7 @@ describe('luidUserPicker', function(){
 				"label": "Nom du manager",
 				"name": "manager.name"
 			}];
-			var tpl = angular.element('<luid-user-picker ng-model="myUser" homonyms-properties="properties"></luid-user-picker>');
+			var tpl = angular.element('<luid-user-picker selected-user="myUser" homonyms-properties="properties"></luid-user-picker>');
 			elt = $compile(tpl)($scope);
 			isolateScope = elt.isolateScope();
 			$scope.$digest();


### PR DESCRIPTION
- add 'ng-model' in ui-select (needed if we want to initialise the selected user)
- add 'selected-user' attribute
- bind 'ng-model' with 'selected-user': not in default behavior of 'ui-select' (see http://plnkr.co/edit/LrlBZBaILnRWS5bfjZYn?p=preview) even if it is in default behavior of simple select (see http://plnkr.co/edit/8OpD2pEpy1X0bGTMx6bi?p=preview)
- update tests u, tests e2e and demo page with 'selected-user'