### PR TITLE
[enh] luifDuration with unit="day" and precision="day" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - [#83](https://github.com/LuccaSA/lucca-ui/issues/83) - You can now use a button as an input addon.
  - [#84](https://github.com/LuccaSA/lucca-ui/issues/84) - luid-daterange, added `close-label` and `close-action` attributes, see [demo page](http://luccasa.github.io/lucca-ui/#/directives#luid-daterange) for more info
  - [#85](https://github.com/LuccaSA/lucca-ui/issues/85) - .dividing class is now supported for nguibs dropdown items
+ - [#87](https://github.com/LuccaSA/lucca-ui/issues/87) - luifDuration, improved support of `unit="day"` and `precision="day"`
 
 ### Resolved issues
 

--- a/js/filters/timeFilters.js
+++ b/js/filters/timeFilters.js
@@ -78,7 +78,7 @@
 		};
 	})
 	// this filter is very ugly and i'm sorry - i'll add lots of comments
-	.filter('luifDuration', function () {
+	.filter('luifDuration', ['$filter', function ($filter) {
 		return function (_duration, _sign, _unit, _precision) {  //expects a duration, returns the duration in the given unit with the given precision
 			var d = moment.duration(_duration);
 
@@ -98,9 +98,15 @@
 
 					if ((_precision === 'd' || _precision === 'day' || _precision === 'days') && d.asDays() > 0) {
 						unit = 0;
-						// Display duration in days, with only one decimal
-						// Hack: I don't want to use basic 'number' filter because I don't want decimal if decimal part is 0
-						values[0] = Math.round(d.asDays()*10)/10;
+						// Determine the number of decimals to display
+						var decimals = 2;
+						var days = d.asDays();
+						if ((days * 10) % 10 === 0) {
+							decimals = 0;
+						} else if ((days * 100) % 10 === 0) {
+							decimals = 1;
+						}
+						values[0] = $filter("number")(days, decimals);
 					} else {
 						// the first unit with a not nul member, if you want 15 minutes expressed in days it will respond 15m
 						unit = values[0] !== 0 ? 0 : values[1] !== 0 ? 1 : values[2] !== 0 ? 2 : values[3] !== 0 ? 3 : 4;
@@ -213,7 +219,7 @@
 
 			return prefix + result;
 		};
-	})
+	}])
 	.filter('luifHumanize', function () {
 		return function (_duration, suffix) {
 			suffix = !!suffix;

--- a/js/filters/timeFilters.js
+++ b/js/filters/timeFilters.js
@@ -96,9 +96,16 @@
 				case 'days':
 					_precision = !!_precision ? _precision : 'h'; // if no precision is provided, we take the next unit
 
-					// the first unit with a not nul member, if you want 15 minutes expressed in days it will respond 15m
-					unit = values[0] !== 0 ? 0 : values[1] !== 0 ? 1 : values[2] !== 0 ? 2 : values[3] !== 0 ? 3 : 4;
-					values[0] = Math.abs(d.asDays() >= 0 ? Math.floor(d.asDays()) : Math.ceil(d.asDays()));
+					if ((_precision === 'd' || _precision === 'day' || _precision === 'days') && d.asDays() > 0) {
+						unit = 0;
+						// Display duration in days, with only one decimal
+						// Hack: I don't want to use basic 'number' filter because I don't want decimal if decimal part is 0
+						values[0] = Math.round(d.asDays()*10)/10;
+					} else {
+						// the first unit with a not nul member, if you want 15 minutes expressed in days it will respond 15m
+						unit = values[0] !== 0 ? 0 : values[1] !== 0 ? 1 : values[2] !== 0 ? 2 : values[3] !== 0 ? 3 : 4;
+						values[0] = Math.abs(d.asDays() >= 0 ? Math.floor(d.asDays()) : Math.ceil(d.asDays()));
+					}
 					break;
 				case undefined:
 				case '': // if no _unit is provided, use hour

--- a/tests/spec/timeFilters.spec.js
+++ b/tests/spec/timeFilters.spec.js
@@ -196,15 +196,16 @@ describe('luif.timefilters', function(){
 		});
 		it('should produce the right results when a unit and a precision are provided', function(){
 			moment.locale('en');
-			expect(luifDuration(90061001, false, 'd', 'd')).toEqual('1d '); 
+			expect(luifDuration(90061001, false, 'd', 'd')).toEqual('1.04d '); 
 			expect(luifDuration(90061001, false, 'd', 'h')).toEqual('1d 1h'); 
 			expect(luifDuration(90061001, false, 'd', 'm')).toEqual('1d 1h01'); 
 			expect(luifDuration(90061001, false, 'd', 's')).toEqual('1d 1h01m01s'); 
 			expect(luifDuration(90061001, false, 'd', 'ms')).toEqual('1d 1h01m01.001s'); 
 
-			expect(luifDuration(90061001, false, 'd', 'd')).toEqual('1d ');
-			expect(luifDuration(600000, false, 'd', 'd')).toEqual('0d ');
-			expect(luifDuration(36000000, false, 'd', 'd')).toEqual('0.4d ');
+			expect(luifDuration(86400000, false, 'd', 'd')).toEqual('1d ');
+			expect(luifDuration(3600000, false, 'd', 'd')).toEqual('0.04d ');
+			expect(luifDuration(21600000, false, 'd', 'd')).toEqual('0.25d ');
+			expect(luifDuration(36000000, false, 'd', 'd')).toEqual('0.42d ');
 			expect(luifDuration(129600000, false, 'd', 'd')).toEqual('1.5d ');
 			expect(luifDuration(259200000, false, 'd', 'd')).toEqual('3d ');
 

--- a/tests/spec/timeFilters.spec.js
+++ b/tests/spec/timeFilters.spec.js
@@ -202,6 +202,12 @@ describe('luif.timefilters', function(){
 			expect(luifDuration(90061001, false, 'd', 's')).toEqual('1d 1h01m01s'); 
 			expect(luifDuration(90061001, false, 'd', 'ms')).toEqual('1d 1h01m01.001s'); 
 
+			expect(luifDuration(90061001, false, 'd', 'd')).toEqual('1d ');
+			expect(luifDuration(600000, false, 'd', 'd')).toEqual('0d ');
+			expect(luifDuration(36000000, false, 'd', 'd')).toEqual('0.4d ');
+			expect(luifDuration(129600000, false, 'd', 'd')).toEqual('1.5d ');
+			expect(luifDuration(259200000, false, 'd', 'd')).toEqual('3d ');
+
 			expect(luifDuration(90061001, false, 'h', 'd')).toEqual(''); 
 			expect(luifDuration(90061001, false, 'h', 'h')).toEqual('25h'); 
 			expect(luifDuration(90061001, false, 'h', 'm')).toEqual('25h01'); 


### PR DESCRIPTION
issue #87 

When we use `luifDuration` with `unit = 'day'` and `precision = 'day'`, we display the value in `luifDuration` as days (and not as days + hours + minutes).

