### PR TITLE
User.picker.bypass.operations.for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.1 - in dev
 
 ### New features
+- luidUserPicker: `bypass-operations-for` attribute - bypass operations filter for a list of user ids
 
 ### Resolved issues
 

--- a/demo/lucca-spe.html
+++ b/demo/lucca-spe.html
@@ -81,25 +81,29 @@
 		<p>
 			Displays the option "All users". This option is displayed when the search input is empty.
 		</p>
+		<p>
+			Bypasses <code>operations</code> filter for some users. It will always display given users if they belong to the set of results, even if they doesn't have access to the operations.
+		</p>
 		<div class="lui dashed divider">
 			<h4 class="lui underline">Supported arguments</h4>
 		</div>
 		<p>
 			<ul class="lui unstyled">
-				<li><code>ng-model</code> : the variable to bind to</li>
-				<li><code>size</code> : the size of the input, supports <code>x-small</code>, <code>small</code>, <code>long</code>, <code>x-long</code>, <code>fitting</code></li>
-				<li><code>on-select</code> : function to execute when an item is selected</li>
-				<li><code>on-remove</code> : function to execute when an item is removed (multi-select or emptying the input)</li>
-				<li><code>control-disabled</code> : boolean indicating if you want the control to be disabled</li>
-				<li><code>show-former-employees</code> : boolean indicating if you want to fetch former employees or not (default:false)</li>
-				<li><code>homonyms-properties</code> : list of properties you want to display in case of homonyms</li>
-				<li><code>custom-filter</code> : function that filters users. For a given user, it returns if he should be kept in the set of results or not. This function should respect the following signature: <code>function(user){ return boolean; }</code></li>
-				<li><code>app-id</code> : the set of results should have access to the application matching this id</li>
-				<li><code>operations</code> : list of operations that the set of results should support for the given application</li>
-				<li><code>custom-info</code> : function that will return the information to display next to each user. It should respect the following signature : <code>function(user) { return string; }</code></li>
-				<li><code>custom-info-async</code> : same as <code>custom-info</code> except it takes an asynchronous function with the following signature: <code>function(user) { return promise; }</code></li>
-				<li><code>display-me-first</code> : boolean indicating if you want to display the connected user as first result if he belongs to the set of results</li>
-				<li><code>display-all-users</code> : boolean indication if you want to display the option "All users" when the search input is empty</li>
+				<li><code>ng-model</code>: the variable to bind to</li>
+				<li><code>size</code>: the size of the input, supports <code>x-small</code>, <code>small</code>, <code>long</code>, <code>x-long</code>, <code>fitting</code></li>
+				<li><code>on-select</code>: function to execute when an item is selected</li>
+				<li><code>on-remove</code>: function to execute when an item is removed (multi-select or emptying the input)</li>
+				<li><code>control-disabled</code>: boolean indicating if you want the control to be disabled</li>
+				<li><code>show-former-employees</code>: boolean indicating if you want to fetch former employees or not (default:false)</li>
+				<li><code>homonyms-properties</code>: list of properties you want to display in case of homonyms</li>
+				<li><code>custom-filter</code>: function that filters users. For a given user, it returns if he should be kept in the set of results or not. This function should respect the following signature: <code>function(user){ return boolean; }</code></li>
+				<li><code>app-id</code>: the set of results should have access to the application matching this id</li>
+				<li><code>operations</code>: list of operations that the set of results should support for the given application</li>
+				<li><code>custom-info</code>: function that will return the information to display next to each user. It should respect the following signature : <code>function(user) { return string; }</code></li>
+				<li><code>custom-info-async</code>: same as <code>custom-info</code> except it takes an asynchronous function with the following signature: <code>function(user) { return promise; }</code></li>
+				<li><code>display-me-first</code>: boolean indicating if you want to display the connected user as first result if he belongs to the set of results</li>
+				<li><code>display-all-users</code>: boolean indication if you want to display the option "All users" when the search input is empty</li>
+				<li><code>bypass-operations-for</code>: list of user ids to display even if they does not have access to operations in <code>operations</code> attribute</li>
 			</ul>
 		</p>
 		<div class="lui dashed divider">
@@ -299,7 +303,7 @@ $scope.yearOfArrivalAsync = function(user){
 			<h4 class="lui underline">Side notes</h4>
 		</div>
 		<p>
-			The directive is tested with karma (65 tests so far) and protractor (13 tests) and will be stable. Follow the <a class="lui fancy link" href="https://github.com/LuccaSA/lucca-ui/releases">release notes of each version of the bower component</a> to know what feature was added and which bug was fixed.
+			The directive is tested with karma (75 tests so far) and protractor (13 tests) and will be stable. Follow the <a class="lui fancy link" href="https://github.com/LuccaSA/lucca-ui/releases">release notes of each version of the bower component</a> to know what feature was added and which bug was fixed.
 		</p>
 	</article>
 

--- a/js/directives/lucca/user-picker.js
+++ b/js/directives/lucca/user-picker.js
@@ -327,7 +327,7 @@
 			promises.push(getHttpMethod("get")(query + appInstanceId + operations));
 			// Send query without operations filter if both bypassOperationsFor and operations are defined
 			if (!!$scope.bypassOperationsFor && !!$scope.bypassOperationsFor.length && !!$scope.operations && !!$scope.operations.length) {
-				promises.push(getHttpMethod("get")(query + appInstanceId));
+				promises.push(getHttpMethod("get")(query));
 			}
 
 			return promises;

--- a/tests/spec/directives/user-picker.spec.js
+++ b/tests/spec/directives/user-picker.spec.js
@@ -1095,13 +1095,13 @@ describe('luidUserPicker', function(){
 		});
 		it("should send one more request without operations filter", function() {
 			$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86\&operations=1,2,3/i).respond(200, RESPONSE_4_users);
-			$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86/i).respond(200, RESPONSE_20_users);
+			$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000/i).respond(200, RESPONSE_20_users);
 			expect($httpBackend.flush).not.toThrow();
 		});
 		describe("when the 2 users does not have access to the operations but should be displayed at the end of the list", function() {
 			beforeEach(function() {
 				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86\&operations=1,2,3/i).respond(200, RESPONSE_3_users);
-				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86/i).respond(200, RESPONSE_20_users);
+				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000/i).respond(200, RESPONSE_20_users);
 				$httpBackend.flush();
 			});
 			it("should add users to the list of displayed users in the right position", function() {
@@ -1111,7 +1111,7 @@ describe('luidUserPicker', function(){
 		describe("when the 2 users does not have access to the operations but should be displayed at the beginning of the list", function() {
 			beforeEach(function() {
 				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86\&operations=1,2,3/i).respond(200, RESPONSE_4_users_end);
-				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86/i).respond(200, RESPONSE_20_users);
+				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000/i).respond(200, RESPONSE_20_users);
 				$httpBackend.flush();
 			});
 			it("should add users to the list of displayed users in the right position", function() {
@@ -1121,7 +1121,7 @@ describe('luidUserPicker', function(){
 		describe("when the 2 users have access to the operations", function() {
 			beforeEach(function() {
 				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86\&operations=1,2,3/i).respond(200, RESPONSE_20_users);
-				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86/i).respond(200, RESPONSE_20_users);
+				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000/i).respond(200, RESPONSE_20_users);
 				$httpBackend.flush();
 			});
 			it("should not update the order of displayed users", function() {
@@ -1131,7 +1131,7 @@ describe('luidUserPicker', function(){
 		describe("when the 2 users does not have access to the operations and should not be displayed", function() {
 			beforeEach(function() {
 				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86\&operations=1,2,3/i).respond(200, RESPONSE_4_users);
-				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86/i).respond(200, RESPONSE_4_users);
+				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000/i).respond(200, RESPONSE_4_users);
 				$httpBackend.flush();
 			});
 			it("should not add users to the list of displayed users", function() {
@@ -1141,7 +1141,7 @@ describe('luidUserPicker', function(){
 		describe("when the 2 users does not have access to the operations but one of them should be displayed", function() {
 			beforeEach(function() {
 				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86\&operations=1,2,3/i).respond(200, RESPONSE_4_users);
-				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000\&appinstanceid=86/i).respond(200, RESPONSE_1_user);
+				$httpBackend.expectGET(/api\/v3\/users\/find\?formerEmployees=false\&limit=10000/i).respond(200, RESPONSE_1_user);
 				$httpBackend.flush();
 			});
 			it("should add the user to the list of displayed users", function() {


### PR DESCRIPTION
Add `bypass-operations-for` attribute: send another request without `operations` filter. If given user ids are fetched, add them to the list of displayed users.