### PR TITLE
Colored.icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - directive deferred-cloak : Used to prevent the Angular html template from being briefly displayed by the browser in its raw (uncompiled) form while your application is loading.
 Based on ng-cloak angular's directive but use link directive function instead of compile function.
 - luidUserPicker: `bypass-operations-for` attribute - bypass operations filter for a list of user ids
+- lui icon - supports palette adjectives to change the icon color
 
 ### Resolved issues
 

--- a/demo/icons.html
+++ b/demo/icons.html
@@ -22,7 +22,10 @@
 		<article id="how-to">
 			<h2 class="lui divider below">How to use</h2>
 			<p>
-				Just append/prepend a <code>&lt;i class="lui icon {icon-name}"&gt;&lt;/i&gt;</code> element.
+				Just append/prepend a <code>&lt;i class="lui {palette} icon {icon-name}"&gt;&lt;/i&gt;</code> element.
+			</p>
+			<p>
+				<code>&lt;i class="lui red icon warning"&gt;&lt;/i&gt;</code>: <i class="lui red icon warning"></i>, <code>&lt;i class="lui primary icon jumpping cc"&gt;&lt;/i&gt;</code>: <i class="lui primary icon jumping cc"></i>
 			</p>
 			<p>
 				<b>Important:</b> the words order is important in the icon-name : <code>lui icon arrow south</code> is not the same that <code>lui icon south arrow</code>

--- a/scss/core/utilities/mixins/_supports-text-coloring.scss
+++ b/scss/core/utilities/mixins/_supports-text-coloring.scss
@@ -1,0 +1,8 @@
+
+@mixin lui_supports_text_coloring() {
+	@each $name, $scheme in luiPalettes() {
+		&.#{map-get($scheme, class)} {
+			color: map-get($scheme, color);
+		}
+	}
+}

--- a/scss/lucca-ui.namespaced.scss
+++ b/scss/lucca-ui.namespaced.scss
@@ -36,6 +36,8 @@ $cleanNamespace: str-replace(to-string($namespace), '#', '');
 @import "core/utilities/mixins/is-animated";
 // Sizing handler
 @import "core/utilities/mixins/supports-sizing";
+// text-color handler handler
+@import "core/utilities/mixins/supports-text-coloring";
 // Loader
 @import "core/utilities/mixins/loader";
 // Triangle maker
@@ -110,6 +112,7 @@ $luccaIcons_font-create-classes: luiTheme(element, icons, createClasses);
 @import "bower_components/lucca-icons/src/lucca-icons";
 // Sizing support
 #{$luccaIcons_icon-base-selector} { @include lui_supports_sizing(); };
+i#{$luccaIcons_icon-base-selector} { @include lui_supports_text_coloring(); };
 // We define a mixin alias here for better support
 @mixin lui_make_icon($name, $position: left) { @include luccaIcons_make($name, $position); }
 


### PR DESCRIPTION
@Clotilde 

adds palette color support for icons, only applies to tag `<i></i>` to avoid drooling over other elements