### PR TITLE
dayblock [fix] june/july both displayed "jui" in french

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Based on ng-cloak angular's directive but use link directive function instead of
 
 ### Resolved issues
 - Popover: unnecessary !important property removed - may break things unexpectedly
+- day block - fix issue with july and june displayed the same in french
 
 ## 2.1.0 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/2.1.0)
 

--- a/js/directives/day-block.js
+++ b/js/directives/day-block.js
@@ -15,7 +15,7 @@
 			'</div>'+
 
 			'<div ng-style="controller.monthStyleOverride()" ' +
-			'class="month">{{controller.date | luifMoment: \'MMM\' | limitTo : 3}}'+
+			'class="month">{{controller.date | luifMoment: \'MMM\'}}'+
 			'</div>'+
 
 			'<div ng-style="controller.yearStyleOverride()" ' +


### PR DESCRIPTION
new version of pr #214 