### PR TITLE
Datepicker.daterange.styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - tablegrid : fixes a translation typo
 - [issue #276](https://github.com/LuccaSA/lucca-ui/issues/276) - tablegrid does not evaluate expression when injecting HTML as ui-select-choices
 - Inputs: fixes input addon sizing
+- `luid-date-picker` - an equivalent to [ui bootstrap datepicker](https://angular-ui.github.io/bootstrap/#/datepicker). see [demo page](https://luccasa.github.io/lucca-ui/#/directives#luid-date-picker) for more info
+- `luid-daterange-picker` - the new and improved version of the luid-daterange. see [demo page](https://luccasa.github.io/lucca-ui/#/directives#luid-daterange-picker) for more info
 
 ## 2.2.3 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/2.2.2)
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,7 @@ module.exports = function(grunt) {
 	grunt.registerTask('dist', ["ts:dist", "ts:distspe", "ngtemplates:dist", 'concat:spe', 'uglify:spe', 'concat:standard', 'uglify:standard', 'sass:dist', "copy:tsdefinitions"]);
 
 	// use this tasks when you are developping
-	grunt.registerTask('debug', ["dist", "ts:test", "connect:server", 'concurrent:debug']);
+	grunt.registerTask('debug', ["dist", "sass:demo", "ts:test", "connect:server", 'concurrent:debug']);
 	// // use this one when you're coding e2e tests
 	grunt.registerTask('e2e', ["dist", "ts:e2e", "connect", "protractor:singlerun", 'concurrent:e2e']);
 	// this updates the dists and tests it, creates karma coverage

--- a/demo/directives.html
+++ b/demo/directives.html
@@ -611,6 +611,8 @@ $scope.myMappings = { 13: enterPressed };</pre>
 					<li><code>custom-class</code>: a function taking in a moment and returnung a string to apply specific classes to some days</li>
 					<li><code>displayed-months</code>: number of months you want displayed next to one another, default <code>1</code></li>
 					<li><code>display-format</code>: unused inline, the format to use to display the selected date in the input, will use <code>format</code> if you provided any or the format <code>L</code> if you didn't</li>
+					<li><code>shortcuts</code>: unused inline, a list of objects <code>{ label: "string", date: "your format of date" }</code> to be displayed under the calendars to easily select a certain date</li>
+					<li><code>grouped-shortcuts</code>: unused inline, like <code>shortcuts</code> but you want them displayed on several lines for consistency, for example you want on one line <code>yesterday</code>, <code>today</code>, <code>tomorrow</code> and on another <code>last week</code>, <code>this week</code>, <code>next week</code></li>
 				</ul>
 			</p>
 			<div class="lui dashed divider">
@@ -696,8 +698,8 @@ $scope.myMappings = { 13: enterPressed };</pre>
 					<!-- <code> lol mdr {{myForm}}</code> -->
 				</p>
 				<p>
-					min: <luid-date-picker-popup ng-model="min" display-format="LL"></luid-date-picker-popup>
-					max: <luid-date-picker-popup ng-model="max" display-format="LL"></luid-date-picker-popup>
+					min: <luid-date-picker-popup ng-model="min" display-format="LL" shortcuts="shortcuts"></luid-date-picker-popup>
+					max: <luid-date-picker-popup ng-model="max" display-format="LL" grouped-shortcuts="groupedShortcuts"></luid-date-picker-popup>
 				</p>
 				<p>
 					<!-- <code>{{myForm.withMinMax}}</code> -->
@@ -753,6 +755,8 @@ $scope.myMappings = { 13: enterPressed };</pre>
 					<li><code>max</code>: self explainatory</li>
 					<li><code>custom-class</code>: a function taking in a moment and returnung a string to apply specific classes to some days</li>
 					<li><code>display-format</code>: used when the popover is open to display each date in its tag, uses <code>format</code> if you provided any or the format <code>L</code> if you didn't</li>
+					<li><code>shortcuts</code>: unused inline, a list of objects <code>{ label: "string", "your-start-property": "your format of date", "your-end-property": "your format of date" }</code> to be displayed under the calendars to easily select a certain daterange</li>
+					<li><code>grouped-shortcuts</code>: unused inline, like <code>shortcuts</code> but you want them displayed on several lines for consistency, for example you want on one line <code>yesterday</code>, <code>today</code>, <code>tomorrow</code> and on another <code>last week</code>, <code>this week</code>, <code>next week</code></li>
 				</ul>
 			</p>
 			<div class="lui dashed divider">
@@ -777,7 +781,7 @@ $scope.myMappings = { 13: enterPressed };</pre>
 					basic usage
 				</p>
 				<p>
-					<luid-daterange-picker ng-model="myDaterange"></luid-daterange-picker>
+					<luid-daterange-picker ng-model="myDaterange" grouped-shortcuts="groupedShortcuts"></luid-daterange-picker>
 				</p>
 				<p>
 					start: <code>{{ myDaterange.start | luifMoment }}</code> - end: <code>{{ myDaterange.end | luifMoment }}</code>
@@ -787,7 +791,7 @@ $scope.myMappings = { 13: enterPressed };</pre>
 					with end excluded and weekend disabled
 				</p>
 				<p>
-					<luid-daterange-picker ng-model="myDaterange2" exclude-end="true" custom-class="disableWeekends"></luid-daterange-picker>
+					<luid-daterange-picker ng-model="myDaterange2" exclude-end="true" custom-class="disableWeekends" shortcuts="shortcuts"></luid-daterange-picker>
 				</p>
 				<p>
 					start: <code>{{ myDaterange2.start | luifMoment }}</code> - end: <code>{{ myDaterange2.end | luifMoment }}</code>

--- a/demo/directives.html
+++ b/demo/directives.html
@@ -723,15 +723,15 @@ $scope.myMappings = { 13: enterPressed };</pre>
 					<luid-date-picker ng-model="dateMoment" displayed-months="2"></luid-date-picker>
 				</p>
 				<p>
-					<luid-date-picker ng-model="dateMoment" displayed-months="3"></luid-date-picker>
+					<luid-date-picker ng-model="dateMoment" displayed-months="2"></luid-date-picker>
 				</p>
 				<p>
 					With multiple months displayed at once in a popup
 				</p>
 				<p>
-					<luid-date-picker-popup ng-model="dateMoment" displayed-months="3"></luid-date-picker-popup>
+					<luid-date-picker-popup ng-model="dateMoment" displayed-months="2"></luid-date-picker-popup>
 				</p>
-				
+
 			</div>
 		</article>
 				<article id="luid-daterange-picker">

--- a/demo/js/directives.js
+++ b/demo/js/directives.js
@@ -111,6 +111,22 @@
 		$scope.highlightThisWeek = function (date) {
 			return date.week() === moment().week() ? "in-between" : "";
 		};
+		$scope.shortcuts = [
+		{ label: "yesterday", date: moment().add(-1, "day").startOf("day") },
+		{ label: "today", date: moment().startOf("day") },
+		{ label: "tomorrow", date: moment().add(1, "day").startOf("day") },
+		{ label: "last monday", date: moment().add(-1, "week").startOf("week") },
+		{ label: "this monday", date: moment().startOf("week") },
+		{ label: "next monday", date: moment().add(1, "week").startOf("week") },
+		];
+		$scope.groupedShortcuts = [
+		[{ label: "yesterday", date: moment().add(-1, "day").startOf("day") },
+		{ label: "today", date: moment().startOf("day") },
+		{ label: "tomorrow", date: moment().add(1, "day").startOf("day") },],
+		[{ label: "last monday", date: moment().add(-1, "week").startOf("week") },
+		{ label: "this monday", date: moment().startOf("week") },
+		{ label: "next monday", date: moment().add(1, "week").startOf("week") },],
+		];
 	}]);
 	angular.module('demoApp')
 	.controller('daterangepickerCtrl', ['$scope', function($scope){
@@ -121,6 +137,19 @@
 		$scope.disableWeekends = function (date) {
 			return (date.isoWeekday() === 7 || date.isoWeekday() === 6) ? "disabled" : "";
 		};
+		$scope.shortcuts = [
+		{ label: "last week", start: moment().add(-1, "week").startOf("week"), end: moment().startOf("week") },
+		{ label: "this week", start: moment().startOf("week"), end: moment().add(1, "week").startOf("week") },
+		{ label: "next week", start: moment().add(1, "week").startOf("week"), end: moment().add(2, "week").startOf("week") },
+		];
+		$scope.groupedShortcuts = [
+		[{ label: "last week", start: moment().add(-1, "week").startOf("week"), end: moment().startOf("week").add(-1, "day") },
+		{ label: "this week", start: moment().startOf("week"), end: moment().add(1, "week").startOf("week").add(-1, "day") },
+		{ label: "next week", start: moment().add(1, "week").startOf("week"), end: moment().add(2, "week").startOf("week").add(-1, "day") },],
+		[{ label: "last month", start: moment().add(-1, "month").startOf("month"), end: moment().startOf("month").add(-1, "day") },
+		{ label: "this month", start: moment().startOf("month"), end: moment().add(1, "month").startOf("month").add(-1, "day") },
+		{ label: "next month", start: moment().add(1, "month").startOf("month"), end: moment().add(2, "month").startOf("month").add(-1, "day") },],
+		];
 	}]);
 	angular.module('demoApp')
 	.controller('progressCtrl', ['$scope', '$http', 'luisProgressBar', function($scope, $http, luisProgressBar){

--- a/dist/lucca-ui.d.ts
+++ b/dist/lucca-ui.d.ts
@@ -30,6 +30,7 @@ declare module Lui.Directives {
         selectDay(day: CalendarDay): void;
         previousMonth(): void;
         nextMonth(): void;
+        direction: string;
         onMouseEnter(day: CalendarDay, $event?: ng.IAngularEvent): void;
         onMouseLeave(day: CalendarDay, $event?: ng.IAngularEvent): void;
     }

--- a/scss/core/elements/_datepicker.scss
+++ b/scss/core/elements/_datepicker.scss
@@ -128,12 +128,6 @@
 					user-select: none;
 				}
 
-				> tbody > tr > td[disabled="disabled"] {
-					border: map-gets($vars, day, disabled, border, width) map-gets($vars, day, disabled, border, style) map-gets($vars, day, disabled, border, color);
-					color: map-gets($vars, day, disabled, color);
-					background-color: map-gets($vars, day, disabled, background-color);
-				}
-
 				> tbody > tr > td.empty {
 					opacity: 0;
 					pointer-events: none;
@@ -174,9 +168,12 @@
 							background-color: map-gets($vars, day, selected, hover, background-color);
 						}
 					}
-					&.disabled {
-						opacity: .5;
+					&.disabled, &[disabled="disabled"] {
+						opacity: map-gets($vars, day, disabled, opacity);
 						pointer-events: none;
+						// border: map-gets($vars, day, disabled, border, width) map-gets($vars, day, disabled, border, style) map-gets($vars, day, disabled, border, color);
+						// color: map-gets($vars, day, disabled, color);
+						// background-color: map-gets($vars, day, disabled, background-color);
 					}
 				}
 			}

--- a/scss/core/elements/_datepicker.scss
+++ b/scss/core/elements/_datepicker.scss
@@ -2,11 +2,37 @@
 
 	@if luiTheme(element, datepicker, enabled) {
 		$vars: luiTheme(element, datepicker);
-		luid-date-picker-popup {
+		luid-date-picker,
+		luid-date-picker-popup,
+		luid-daterange-picker {
+			display: inline-block;
+		}
+		luid-date-picker-popup,
+		luid-daterange-picker {
 			> .lui.input {
+				position: relative;
 				width: map-gets($vars, input, width);
+
+				input {
+					padding-right: 2.25em;
+				}
+
+				&.empty {
+					i.empty { display: none; }
+					@include lui_make_icon("calendar", right);
+					&:after {
+						position: absolute;
+						top: luiTheme(element, input, borderWidth);
+						right: 0.5em;
+						line-height: 1 +  luiTheme(element, input, padding, top) +  luiTheme(element, input, padding, bottom);
+					}
+				}
 			}
-		};
+			> .popover > .popover-inner {
+				text-align: center;
+			}
+
+		}
 		luid-daterange-picker {
 			> .lui.tagged.input {
 				width: 2 * map-gets($vars, input, width);
@@ -14,20 +40,61 @@
 					cursor: pointer;
 				}
 			}
-			.popover-inner {
-				// TEMP
-				width: 40em;
-			}
-		};
+		}
+
 		luid-date-picker,
-		luid-date-picker-popup > .popover > .popover-inner > .popover-content,
-		luid-daterange-picker > .popover > .popover-inner > .popover-content {
-			display: inline-block;
+		luid-date-picker-popup .popover-content,
+		luid-daterange-picker .popover-content {
+			position: relative;
+
+			> button.previous,
+			> button.next {
+				display: block;
+				background: transparent;
+				border: none;
+				outline: 0; outline: none;
+
+				position: absolute;
+				z-index: 2;
+				top: 0.5em;
+
+				padding: 0.5em 1em;
+				border-radius: 3px;
+
+				font-family: 'lucca-icons';
+				font-size: lui_rem(0.8);
+
+				&:hover {
+					background-color: luiPalette(light, color, light);
+				}
+			}
+			> button.previous {
+				left: 1em;
+				&:before {
+					content: "\e053";
+				}
+			}
+			> button.next {
+				right: 1em;
+				&:before {
+					content: "\e054";
+				}
+			}
 
 			> table {
-				display: inline;
-				margin: .5em;
+				display: inline-block;
+				vertical-align: top;
+				margin: 0 .25em;
 				border-collapse: collapse;
+
+				@extend %#{$cleanNamespace}-animated;
+
+				&.previous {
+					animation-name: leftFadeIn;
+				}
+				&.next {
+					animation-name: rightFadeIn;
+				}
 
 				> caption {
 					padding: map-gets($vars, header, padding, vertical) map-gets($vars, header, padding, horizontal);
@@ -39,35 +106,6 @@
 						display: inline-block;
 						vertical-align: middle;
 					}
-
-					> button.previous,
-					> button.next {
-						display: inline-block;
-						background: transparent;
-						border: none;
-						outline: 0; outline: none;
-
-						padding: 0.5em 1em;
-						border-radius: 3px;
-
-						font-family: 'lucca-icons';
-						font-size: lui_rem(0.8);
-
-						&:hover {
-							background-color: luiPalette(light, color, light);
-						}
-					}
-					> button.previous {
-						float: left;
-						&:before {
-							content: "\e053";
-						}
-					}
-					> button.next {
-						float: right;
-						&:before {
-							content: "\e054";
-						}					}
 				}
 
 				> tbody > tr > td,
@@ -90,7 +128,7 @@
 					user-select: none;
 				}
 
-				> tbody > tr > td.disabled {
+				> tbody > tr > td[disabled="disabled"] {
 					border: map-gets($vars, day, disabled, border, width) map-gets($vars, day, disabled, border, style) map-gets($vars, day, disabled, border, color);
 					color: map-gets($vars, day, disabled, color);
 					background-color: map-gets($vars, day, disabled, background-color);
@@ -140,9 +178,56 @@
 						opacity: .5;
 						pointer-events: none;
 					}
-
 				}
 			}
+
+			> footer {
+				text-align: left;
+				padding: 1em 0;
+
+				ul { list-style: none; margin: 0; padding: 0; }
+				li { margin: 0; padding: 0; }
+
+				li.group {
+
+				}
+				li.shortcut {
+					display: inline-block;
+				}
+			}
+		}
+
+		luid-daterange-picker .popover-content,
+		luid-date-picker-popup .popover-content {
+			> footer {
+				background-color: map-gets($vars, popup, footer, background);
+				margin: 0.5em -1em -1em -1em;
+				padding: 0.5em 1em;
+				border-top: 1px solid luiTheme(element, divider, color);
+			}
+		}
+
+		luid-daterange-picker {
+			> .lui.input > .tags {
+				display: block;
+				width: 100%;
+				text-align: center;
+
+				user-select: none;
+				-moz-user-select: none;
+				-webkit-user-select: none;
+				-ms-user-select: none;
+
+				.arrow.icon {
+					font-size: 0.5em;
+					margin: 0 1em;
+				}
+			}
+		}
+
+		luid-daterange-picker,
+		luid-date-picker-popup[displayed-months="2"] {
+			.popover-inner { width: 40em; }
 		}
 	}
 }

--- a/scss/core/elements/_input.scss
+++ b/scss/core/elements/_input.scss
@@ -98,6 +98,27 @@
 			> input[type="checkbox"] {
 				width: auto;
 			}
+
+			i.empty {
+				@include lui_make_icon("cross");
+				font-style: normal;
+				cursor: pointer;
+
+				font-size: lui_rem((1/2));
+				width: lui_rem(1.25); height: lui_rem(1.25);
+				text-align: center;
+				border-radius: 50%;
+
+				&, &:before {
+					position: absolute;
+					top: 50%; transform: translateY(-50%);
+				}
+				right: 1em;
+				&:before { right:  0.6em; margin: 0; }
+
+				background: map-gets($vars, borderColor);
+				color: #FFF;
+			}
 		}
 
 		// Text inputs

--- a/scss/core/elements/_input.search.scss
+++ b/scss/core/elements/_input.search.scss
@@ -22,27 +22,6 @@
 				@extend %lui_user_select_none;
 			}
 
-			i.empty {
-				@include lui_make_icon("cross");
-				font-style: normal;
-				cursor: pointer;
-
-				font-size: lui_rem((1/2));
-				width: lui_rem(1.25); height: lui_rem(1.25);
-				text-align: center;
-				border-radius: 50%;
-
-				&, &:before {
-					position: absolute;
-					top: 50%; transform: translateY(-50%);
-				}
-				right: 1em;
-				&:before { right:  0.6em; margin: 0; }
-
-				background: map-gets($vars, borderColor);
-				color: #FFF;
-			}
-
 			// Tags
 			// ====
 			&.tagged {

--- a/scss/core/elements/_input.tagged.scss
+++ b/scss/core/elements/_input.tagged.scss
@@ -34,6 +34,10 @@
 					background-color: map-gets($vars, tag, selectedColor);
 				}
 
+				&:hover {
+					background-color: lighten(saturate(map-gets($vars, tag, selectedColor), 75), 25);
+				}
+
 				a.close {
 					display: inline-block;
 					vertical-align: middle;

--- a/scss/themes/default/core/elements/_datepicker.defaults.scss
+++ b/scss/themes/default/core/elements/_datepicker.defaults.scss
@@ -89,6 +89,12 @@ $datepicker: (
 				color: luiPalette(primary, text),
 			)
 		)
+	),
+
+	popup: (
+		footer: (
+			background: #FAFAFA
+		)
 	)
 );
 $luiTheme: luiSetTheme(element, datepicker, $datepicker);

--- a/scss/themes/default/core/elements/_datepicker.defaults.scss
+++ b/scss/themes/default/core/elements/_datepicker.defaults.scss
@@ -36,6 +36,7 @@ $datepicker: (
 		disabled: (
 			background-color: #FFF,
 			color: luiPalette(light, color),
+			opacity: .5,
 
 			border: (
 				width: 1px,

--- a/ts/date-picker/calendar.controller.spec.ts
+++ b/ts/date-picker/calendar.controller.spec.ts
@@ -18,12 +18,13 @@ module Lui.Directives.Test {
 		let ctrl: ICalendarController;
 		let $scope: ICalendarScope;
 		beforeEach(inject((
-			_$rootScope_: ng.IRootScopeService
+			_$rootScope_: ng.IRootScopeService,
+			_$log_: ng.ILogService
 		) => {
 			moment.locale("fr");
 			$scope = <ICalendarScope>_$rootScope_.$new();
 			createController = () => {
-				return <ICalendarController>(<any>new CalendarController($scope));
+				return <ICalendarController>(<any>new CalendarController($scope, _$log_));
 			};
 		}));
 		describe("constructMonths", () => {

--- a/ts/date-picker/calendar.controller.ts
+++ b/ts/date-picker/calendar.controller.ts
@@ -41,6 +41,7 @@ module Lui.Directives {
 		selectDay(day: CalendarDay): void;
 		previousMonth(): void;
 		nextMonth(): void;
+		direction: string;
 
 		onMouseEnter(day: CalendarDay, $event?: ng.IAngularEvent): void;
 		onMouseLeave(day: CalendarDay, $event?: ng.IAngularEvent): void;
@@ -111,11 +112,13 @@ module Lui.Directives {
 			$scope.nextMonth = () => {
 				this.currentMonth.add(1, "month");
 				$scope.months = this.constructMonths();
+				$scope.direction = "next";
 				this.assignClasses();
 			};
 			$scope.previousMonth = () => {
 				this.currentMonth.add(-1, "month");
 				$scope.months = this.constructMonths();
+				$scope.direction = "previous";
 				this.assignClasses();
 			};
 		}

--- a/ts/date-picker/calendar.controller.ts
+++ b/ts/date-picker/calendar.controller.ts
@@ -55,17 +55,23 @@ module Lui.Directives {
 		protected monthsCnt: number;
 		protected currentMonth: moment.Moment;
 		protected $scope: ICalendarScope;
+		protected $log: ng.ILogService;
 		protected selected: moment.Moment;
 		protected start: moment.Moment;
 		protected end: moment.Moment;
 		protected min: moment.Moment;
 		protected max: moment.Moment;
-		constructor($scope: ICalendarScope) {
+		constructor($scope: ICalendarScope, $log: ng.ILogService) {
 			this.$scope = $scope;
+			this.$log = $log;
 			this.initCalendarScopeMethods($scope);
 		}
-		public setMonthsCnt(cntStr?: string): void {
+		public setMonthsCnt(cntStr?: string, inAPopover?: boolean): void {
 			this.monthsCnt = parseInt(cntStr, 10) || 1;
+			if (inAPopover && this.monthsCnt > 2) {
+				this.monthsCnt = 2;
+				this.$log.warn("no more than 2 months displayed in a date-picker popover");
+			}
 		}
 		protected constructMonths(): CalendarMonth[] {
 			return _.map(_.range(this.monthsCnt), (offset: number): CalendarMonth => {

--- a/ts/date-picker/calendar.controller.ts
+++ b/ts/date-picker/calendar.controller.ts
@@ -28,6 +28,10 @@ module Lui.Directives {
 			this.dayNum = date.date();
 		}
 	}
+	export class Shortcut {
+		public label: string;
+		public date: moment.Moment | Date | string;
+	}
 	export interface ICalendarScope extends ng.IScope {
 		customClass: (date: moment.Moment) => string;
 		displayedMonths: string;
@@ -40,6 +44,7 @@ module Lui.Directives {
 		direction: string;
 
 		selectDay(day: CalendarDay): void;
+		selectShortcut(shortcut: Shortcut): void;
 		previousMonth(): void;
 		nextMonth(): void;
 

--- a/ts/date-picker/calendar.controller.ts
+++ b/ts/date-picker/calendar.controller.ts
@@ -37,11 +37,11 @@ module Lui.Directives {
 
 		dayLabels: string[];
 		months: CalendarMonth[];
+		direction: string;
 
 		selectDay(day: CalendarDay): void;
 		previousMonth(): void;
 		nextMonth(): void;
-		direction: string;
 
 		onMouseEnter(day: CalendarDay, $event?: ng.IAngularEvent): void;
 		onMouseLeave(day: CalendarDay, $event?: ng.IAngularEvent): void;

--- a/ts/date-picker/datepicker-inline.html
+++ b/ts/date-picker/datepicker-inline.html
@@ -1,15 +1,44 @@
-<table ng-repeat="month in months">
+<button class="previous" ng-click="previousMonth()"></button>
+<button class="next" ng-click="nextMonth()"></button>
+
+<table ng-repeat="month in months" ng-class="[direction]">
 	<caption>
-		<button class="previous" ng-if="$first" ng-click="previousMonth()"></button>
 		<span>{{ month.date | luifMoment : month.currentYear ? "MMMM" : "MMMM - YYYY" }}</span>
-		<button class="next" ng-if="$last" ng-click="nextMonth()"></button>
 	</caption>
 	<thead>
 		<th ng-repeat="dayLabel in dayLabels">{{ ::dayLabel }}</th>
 	</thead>
 	<tbody>
 		<tr ng-repeat="week in month.weeks">
-			<td ng-repeat="day in week.days" ng-class="[{disabled: day.disabled, empty: day.empty, selected: day.selected}, day.customClass]" ng-click="selectDay(day)">{{ ::day.dayNum }}</td>
+			<td ng-repeat="day in week.days"
+				ng-class="[{empty: day.empty, selected: day.selected}, day.customClass]"
+				ng-disabled="day.disabled"
+				ng-click="selectDay(day)">{{ ::day.dayNum }}</td>
 		</tr>
 	</tbody>
 </table>
+
+<footer>
+	<ul>
+		<li class="group" ng-repeatt="group in shortcuts">
+			<ul>
+				<li class="shortcut" ng-repeatt="shortcut in group">
+					<a class="lui small grey wired button" ng-click="">Today</a>
+				</li>
+				<li class="shortcut">
+					<a class="lui small grey wired button" ng-click="">Yesterday</a>
+				</li>
+			</ul>
+		</li>
+		<li class="group">
+			<ul>
+				<li class="shortcut" ng-repeatt="shortcut in group">
+					<a class="lui small grey wired button" ng-click="">This week</a>
+				</li>
+				<li class="shortcut">
+					<a class="lui small grey wired button" ng-click="">Last week</a>
+				</li>
+			</ul>
+		</li>
+	</ul>
+</footer>

--- a/ts/date-picker/datepicker-inline.html
+++ b/ts/date-picker/datepicker-inline.html
@@ -18,25 +18,19 @@
 	</tbody>
 </table>
 
-<footer ng-if="!!shortcuts">
+<footer ng-if="!!shortcuts || !!groupedShortcuts">
 	<ul>
-		<li class="group" ng-repeat="group in shortcuts">
+		<li>
 			<ul>
-				<li class="shortcut" ng-repeat="shortcut in group">
-					<a class="lui small grey wired button" ng-click="">Today</a>
-				</li>
-				<li class="shortcut">
-					<a class="lui small grey wired button" ng-click="">Yesterday</a>
+				<li class="shortcut" ng-repeat="shortcut in shortcuts">
+					<a class="lui small grey wired button" ng-click="selectShortcut(shortcut)">{{ ::shortcut.label }}</a>
 				</li>
 			</ul>
 		</li>
-		<li class="group">
+		<li class="group" ng-repeat="group in groupedShortcuts">
 			<ul>
-				<li class="shortcut" ng-repeatt="shortcut in group">
-					<a class="lui small grey wired button" ng-click="">This week</a>
-				</li>
-				<li class="shortcut">
-					<a class="lui small grey wired button" ng-click="">Last week</a>
+				<li class="shortcut" ng-repeat="shortcut in group">
+					<a class="lui small grey wired button" ng-click="selectShortcut(shortcut)">{{ ::shortcut.label }}</a>
 				</li>
 			</ul>
 		</li>

--- a/ts/date-picker/datepicker-inline.html
+++ b/ts/date-picker/datepicker-inline.html
@@ -18,11 +18,11 @@
 	</tbody>
 </table>
 
-<footer>
+<footer ng-if="!!shortcuts">
 	<ul>
-		<li class="group" ng-repeatt="group in shortcuts">
+		<li class="group" ng-repeat="group in shortcuts">
 			<ul>
-				<li class="shortcut" ng-repeatt="shortcut in group">
+				<li class="shortcut" ng-repeat="shortcut in group">
 					<a class="lui small grey wired button" ng-click="">Today</a>
 				</li>
 				<li class="shortcut">

--- a/ts/date-picker/datepicker-popup.html
+++ b/ts/date-picker/datepicker-popup.html
@@ -7,7 +7,7 @@
 	ng-class="{ 'empty': !displayStr }"
 	ng-click="togglePopover($event)">
 	<input  type="text"
-			ng-disabled="popover.isOpen"
-			ng-model="displayStr">
-	<i class="empty" ng-click=""></i>
+	ng-disabled="popover.isOpen"
+	ng-model="displayStr">
+	<i class="empty" ng-click="clear($event)"></i>
 </span>

--- a/ts/date-picker/datepicker-popup.html
+++ b/ts/date-picker/datepicker-popup.html
@@ -1,8 +1,13 @@
 <span class="lui input"
 	uib-popover-template="'lui/templates/date-picker/datepicker-inline.html'"
 	popover-placement="bottom-left"
-	popover-trigger="none" popover-is-open="popover.isOpen"
+	popover-trigger="none"
+	popover-is-open="popover.isOpen"
 	popover-class="lui luid-datepicker"
+	ng-class="{ 'empty': !displayStr }"
 	ng-click="togglePopover($event)">
-	<input type="text" ng-disabled="popover.isOpen" ng-model="displayStr">
+	<input  type="text"
+			ng-disabled="popover.isOpen"
+			ng-model="displayStr">
+	<i class="empty" ng-click=""></i>
 </span>

--- a/ts/date-picker/datepicker.directive.ts
+++ b/ts/date-picker/datepicker.directive.ts
@@ -115,6 +115,14 @@ module Lui.Directives {
 				this.assignClasses();
 				$event.stopPropagation();
 			};
+			$scope.selectShortcut = (shortcut: Shortcut) => {
+				let date = this.formatter.parseValue(shortcut.date);
+				this.setViewValue(date);
+				this.$scope.displayStr = this.getDisplayStr(date);
+				this.closePopover();
+				this.selected = date;
+				this.assignClasses();
+			};
 		}
 		// set stuff - is called in the linq function
 		public setNgModelCtrl(ngModelCtrl: ng.INgModelController): void {

--- a/ts/date-picker/datepicker.directive.ts
+++ b/ts/date-picker/datepicker.directive.ts
@@ -165,11 +165,13 @@ module Lui.Directives {
 			}
 		}
 		private closePopover(): void {
+			this.$scope.direction = "";
 			if (!!this.popoverController) {
 				this.popoverController.close();
 			}
 		}
 		private openPopover($event: ng.IAngularEvent): void {
+			this.$scope.direction = "";
 			if (!!this.popoverController) {
 				this.popoverController.open($event);
 			}

--- a/ts/date-picker/datepicker.directive.ts
+++ b/ts/date-picker/datepicker.directive.ts
@@ -39,6 +39,8 @@ module Lui.Directives {
 			min: "=",
 			max: "=",
 			customClass: "=",
+			shortcuts: "=",
+			groupedShortcuts: "=",
 		};
 		public controller: string = LuidDatePickerController.IID;
 		public static factory(): angular.IDirectiveFactory {

--- a/ts/date-picker/datepicker.directive.ts
+++ b/ts/date-picker/datepicker.directive.ts
@@ -52,7 +52,7 @@ module Lui.Directives {
 			let datePickerCtrl = <LuidDatePickerController>ctrls[1];
 			datePickerCtrl.setNgModelCtrl(ngModelCtrl);
 			datePickerCtrl.setFormat(scope.format, scope.displayFormat);
-			datePickerCtrl.setMonthsCnt(scope.displayedMonths);
+			datePickerCtrl.setMonthsCnt(scope.displayedMonths, true);
 			datePickerCtrl.setPopoverTrigger(element, scope);
 		}
 	}
@@ -70,15 +70,15 @@ module Lui.Directives {
 
 	class LuidDatePickerController extends CalendarController {
 		public static IID: string = "luidDatePickerController";
-		public static $inject: Array<string> = ["$scope"];
+		public static $inject: Array<string> = ["$scope", "$log"];
 		protected $scope: IDatePickerScope;
 		private formatter: Lui.Utils.IFormatter<moment.Moment>;
 		private ngModelCtrl: ng.INgModelController;
 		private displayFormat: string;
 		private popoverController: Lui.Utils.IPopoverController;
 
-		constructor($scope: IDatePickerScope) {
-			super($scope);
+		constructor($scope: IDatePickerScope, $log: ng.ILogService) {
+			super($scope, $log);
 			this.$scope = $scope;
 			$scope.selectDay = (day: CalendarDay) => {
 				this.setViewValue(day.date);

--- a/ts/date-picker/datepicker.directive.ts
+++ b/ts/date-picker/datepicker.directive.ts
@@ -64,7 +64,8 @@ module Lui.Directives {
 		displayStr: string;
 		displayFormat: string;
 
-		togglePopover: ($event: ng.IAngularEvent) => void;
+		togglePopover($event: ng.IAngularEvent): void;
+		clear($event: ng.IAngularEvent): void;
 	}
 
 	class LuidDatePickerController extends CalendarController {
@@ -103,6 +104,15 @@ module Lui.Directives {
 				this.selected = this.getViewValue();
 				this.assignClasses();
 			});
+
+			$scope.clear = ($event: ng.IAngularEvent) => {
+				this.setViewValue(undefined);
+				this.$scope.displayStr = "";
+				this.closePopover();
+				this.selected = undefined;
+				this.assignClasses();
+				$event.stopPropagation();
+			};
 		}
 		// set stuff - is called in the linq function
 		public setNgModelCtrl(ngModelCtrl: ng.INgModelController): void {

--- a/ts/date-picker/daterangepicker-popover.html
+++ b/ts/date-picker/daterangepicker-popover.html
@@ -19,25 +19,12 @@
 	</tbody>
 </table>
 
-<footer>
+<footer ng-if="!!shortcuts">
 	<ul>
-		<li class="group" ng-repeatt="group in shortcuts">
+		<li class="group" ng-repeat="group in shortcuts">
 			<ul>
-				<li class="shortcut" ng-repeatt="shortcut in group">
-					<a class="lui small grey wired button" ng-click="">Today</a>
-				</li>
-				<li class="shortcut">
-					<a class="lui small grey wired button" ng-click="">Yesterday</a>
-				</li>
-			</ul>
-		</li>
-		<li class="group">
-			<ul>
-				<li class="shortcut" ng-repeatt="shortcut in group">
-					<a class="lui small grey wired button" ng-click="">This week</a>
-				</li>
-				<li class="shortcut">
-					<a class="lui small grey wired button" ng-click="">Last week</a>
+				<li class="shortcut" ng-repeat="shortcut in group">
+					<a class="lui small grey wired button" ng-click="selectShortcut(shortcut)">{{ ::shortcut.label }}</a>
 				</li>
 			</ul>
 		</li>

--- a/ts/date-picker/daterangepicker-popover.html
+++ b/ts/date-picker/daterangepicker-popover.html
@@ -1,8 +1,9 @@
-<table ng-repeat="month in months">
+<button class="previous" ng-click="previousMonth()"></button>
+<button class="next" ng-click="nextMonth()"></button>
+
+<table ng-repeat="month in months" ng-class="[direction]">
 	<caption>
-		<button class="previous" ng-if="$first" ng-click="previousMonth()"></button>
 		<span>{{ month.date | luifMoment : month.currentYear ? "MMMM" : "MMMM - YYYY" }}</span>
-		<button class="next" ng-if="$last" ng-click="nextMonth()"></button>
 	</caption>
 	<thead>
 		<th ng-repeat="dayLabel in dayLabels">{{ ::dayLabel }}</th>
@@ -10,9 +11,35 @@
 	<tbody>
 		<tr ng-repeat="week in month.weeks">
 			<td ng-repeat="day in week.days"
-			ng-class="[{ empty: day.empty, start: day.start, end: day.end, 'in-between': day.inBetween, 'disabled': day.disabled }, day.customClass]"
-			ng-click="selectDay(day)"
-			ng-mouseenter="onMouseEnter(day)" ng-mouseleave="onMouseLeave(day)">{{ ::day.dayNum }}</td>
+				ng-class="[{ empty: day.empty, start: day.start, end: day.end, 'in-between': day.inBetween }, day.customClass]"
+				ng-disabled="day.disabled"
+				ng-click="selectDay(day)"
+				ng-mouseenter="onMouseEnter(day)" ng-mouseleave="onMouseLeave(day)">{{ ::day.dayNum }}</td>
 		</tr>
 	</tbody>
 </table>
+
+<footer>
+	<ul>
+		<li class="group" ng-repeatt="group in shortcuts">
+			<ul>
+				<li class="shortcut" ng-repeatt="shortcut in group">
+					<a class="lui small grey wired button" ng-click="">Today</a>
+				</li>
+				<li class="shortcut">
+					<a class="lui small grey wired button" ng-click="">Yesterday</a>
+				</li>
+			</ul>
+		</li>
+		<li class="group">
+			<ul>
+				<li class="shortcut" ng-repeatt="shortcut in group">
+					<a class="lui small grey wired button" ng-click="">This week</a>
+				</li>
+				<li class="shortcut">
+					<a class="lui small grey wired button" ng-click="">Last week</a>
+				</li>
+			</ul>
+		</li>
+	</ul>
+</footer>

--- a/ts/date-picker/daterangepicker-popover.html
+++ b/ts/date-picker/daterangepicker-popover.html
@@ -19,9 +19,16 @@
 	</tbody>
 </table>
 
-<footer ng-if="!!shortcuts">
+<footer ng-if="!!shortcuts || !!groupedShortcuts">
 	<ul>
-		<li class="group" ng-repeat="group in shortcuts">
+		<li>
+			<ul>
+				<li class="shortcut" ng-repeat="shortcut in shortcuts">
+					<a class="lui small grey wired button" ng-click="selectShortcut(shortcut)">{{ ::shortcut.label }}</a>
+				</li>
+			</ul>
+		</li>
+		<li class="group" ng-repeat="group in groupedShortcuts">
 			<ul>
 				<li class="shortcut" ng-repeat="shortcut in group">
 					<a class="lui small grey wired button" ng-click="selectShortcut(shortcut)">{{ ::shortcut.label }}</a>

--- a/ts/date-picker/daterangepicker.html
+++ b/ts/date-picker/daterangepicker.html
@@ -6,7 +6,7 @@
 	ng-click="togglePopover($event)"
 	ng-class="{ 'open': popover.isOpen, 'empty': !displayStr }">
 	<input type="text" ng-hide="popover.isOpen" ng-model="displayStr">
-	<i class="empty" ng-click=""></i>
+	<i class="empty" ng-click="clear($event)"></i>
 	<span class="tags" ng-show="popover.isOpen">
 		<span class="tag" ng-class="{ selected: editingStart }" ng-click="editStart($event)">{{ !!period.start ? (period.start | luifMoment : momentFormat) : "From" }}</span>
 		<i class="lui east arrow icon"></i>

--- a/ts/date-picker/daterangepicker.html
+++ b/ts/date-picker/daterangepicker.html
@@ -3,11 +3,13 @@
 	popover-placement="bottom-left"
 	popover-trigger="none" popover-is-open="popover.isOpen"
 	popover-class="lui luid-daterangepicker"
-	ng-click="togglePopover($event)">
+	ng-click="togglePopover($event)"
+	ng-class="{ 'open': popover.isOpen, 'empty': !displayStr }">
 	<input type="text" ng-hide="popover.isOpen" ng-model="displayStr">
+	<i class="empty" ng-click=""></i>
 	<span class="tags" ng-show="popover.isOpen">
-		<span class="tag" ng-class="{ selected: editingStart }" ng-click="editStart($event)">{{ !!period.start ? (period.start | luifMoment : momentFormat) : "................." }}</span>
+		<span class="tag" ng-class="{ selected: editingStart }" ng-click="editStart($event)">{{ !!period.start ? (period.start | luifMoment : momentFormat) : "From" }}</span>
 		<i class="lui east arrow icon"></i>
-		<span class="tag" ng-class="{ selected: !editingStart }" ng-click="editEnd($event)">{{ !!period.end ? (period.end | luifMoment : momentFormat) : "................." }}</span>
+		<span class="tag" ng-class="{ selected: !editingStart }" ng-click="editEnd($event)">{{ !!period.end ? (period.end | luifMoment : momentFormat) : "To" }}</span>
 	</span>
 </span>

--- a/ts/date-picker/daterangepicker.html
+++ b/ts/date-picker/daterangepicker.html
@@ -8,8 +8,8 @@
 	<input type="text" ng-hide="popover.isOpen" ng-model="displayStr">
 	<i class="empty" ng-click="clear($event)"></i>
 	<span class="tags" ng-show="popover.isOpen">
-		<span class="tag" ng-class="{ selected: editingStart }" ng-click="editStart($event)">{{ !!period.start ? (period.start | luifMoment : momentFormat) : "From" }}</span>
+		<span class="tag" ng-class="{ selected: editingStart }" ng-click="editStart($event)">{{ !!period.start ? (period.start | luifMoment : momentFormat) : fromLabel }}</span>
 		<i class="lui east arrow icon"></i>
-		<span class="tag" ng-class="{ selected: !editingStart }" ng-click="editEnd($event)">{{ !!period.end ? (period.end | luifMoment : momentFormat) : "To" }}</span>
+		<span class="tag" ng-class="{ selected: !editingStart }" ng-click="editEnd($event)">{{ !!period.end ? (period.end | luifMoment : momentFormat) : toLabel }}</span>
 	</span>
 </span>

--- a/ts/date-picker/daterangepricker.directive.ts
+++ b/ts/date-picker/daterangepricker.directive.ts
@@ -16,6 +16,9 @@ module Lui.Directives {
 			excludeEnd: "@",
 			startProperty: "@",
 			endProperty: "@",
+
+			shortcuts: "=",
+			groupedShortcuts: "=",
 		};
 		public controller: string = LuidDaterangePickerController.IID;
 		public static factory(): angular.IDirectiveFactory {

--- a/ts/date-picker/daterangepricker.directive.ts
+++ b/ts/date-picker/daterangepricker.directive.ts
@@ -107,6 +107,13 @@ module Lui.Directives {
 					$scope.editStart();
 				}
 			};
+			$scope.selectShortcut = (shortcut: Shortcut) => {
+				$scope.period = this.toPeriod(shortcut);
+				$scope.displayStr = this.$filter("luifFriendlyRange")(this.$scope.period);
+				this.setViewValue($scope.period);
+				this.closePopover();
+			};
+
 			$scope.editStart = ($event?: ng.IAngularEvent) => {
 				if (!!$event) {
 					$event.stopPropagation();
@@ -216,16 +223,19 @@ module Lui.Directives {
 		}
 		private getViewValue(): Lui.Period {
 			if (!!this.ngModelCtrl.$viewValue) {
-				let iperiod: Lui.IPeriod = {};
-				iperiod.start = this.ngModelCtrl.$viewValue[this.startProperty];
-				iperiod.end = this.ngModelCtrl.$viewValue[this.endProperty];
-				let period = new Lui.Period(iperiod, this.formatter);
-				if (this.excludeEnd) {
-					period.end.add(-1, "day");
-				}
-				return period;
+				return this.toPeriod(this.ngModelCtrl.$viewValue);
 			}
 			return { start: undefined, end: undefined };
+		}
+		private toPeriod(v: any): Lui.Period {
+			let iperiod: Lui.IPeriod = {};
+			iperiod.start = v[this.startProperty];
+			iperiod.end = v[this.endProperty];
+			let period = new Lui.Period(iperiod, this.formatter);
+			if (this.excludeEnd) {
+				period.end.add(-1, "day");
+			}
+			return period;
 		}
 
 		// popover logic

--- a/ts/date-picker/daterangepricker.directive.ts
+++ b/ts/date-picker/daterangepricker.directive.ts
@@ -232,7 +232,7 @@ module Lui.Directives {
 			iperiod.start = v[this.startProperty];
 			iperiod.end = v[this.endProperty];
 			let period = new Lui.Period(iperiod, this.formatter);
-			if (this.excludeEnd) {
+			if (this.excludeEnd && !!period.end) {
 				period.end.add(-1, "day");
 			}
 			return period;

--- a/ts/date-picker/daterangepricker.directive.ts
+++ b/ts/date-picker/daterangepricker.directive.ts
@@ -61,7 +61,7 @@ module Lui.Directives {
 
 	class LuidDaterangePickerController extends CalendarController {
 		public static IID: string = "luidDaterangePickerController";
-		public static $inject: Array<string> = ["$scope", "$filter"];
+		public static $inject: Array<string> = ["$scope", "$filter", "$log"];
 		protected $scope: IDaterangePickerScope;
 		private formatter: Lui.Utils.IFormatter<moment.Moment>;
 		private ngModelCtrl: ng.INgModelController;
@@ -71,8 +71,8 @@ module Lui.Directives {
 		private startProperty: string;
 		private endProperty: string;
 
-		constructor($scope: IDaterangePickerScope, $filter: Lui.ILuiFilters) {
-			super($scope);
+		constructor($scope: IDaterangePickerScope, $filter: Lui.ILuiFilters, $log: ng.ILogService) {
+			super($scope, $log);
 			this.$scope = $scope;
 			this.$filter = $filter;
 

--- a/ts/date-picker/daterangepricker.directive.ts
+++ b/ts/date-picker/daterangepricker.directive.ts
@@ -74,7 +74,7 @@ module Lui.Directives {
 			this.$scope = $scope;
 			this.$filter = $filter;
 			$scope.selectDay = (day: CalendarDay) => {
-				if ($scope.editingStart || !!$scope.period.start && day.date.isBefore($scope.period.start)) {
+				if ($scope.editingStart || (!!$scope.period.start && day.date.isBefore($scope.period.start))) {
 					$scope.period.start = day.date;
 					this.start = day.date;
 					$scope.editEnd();
@@ -83,9 +83,12 @@ module Lui.Directives {
 						this.end = undefined;
 					}
 					this.assignClasses();
-				} else {
+				} else if (!$scope.editingStart && !!$scope.period.start) {
 					$scope.period.end = day.date;
 					this.closePopover();
+				} else {
+					$scope.period.end = day.date;
+					$scope.editStart();
 				}
 			};
 			$scope.editStart = ($event?: ng.IAngularEvent) => {

--- a/ts/date-picker/daterangepricker.directive.ts
+++ b/ts/date-picker/daterangepricker.directive.ts
@@ -52,7 +52,8 @@ module Lui.Directives {
 		displayStr: string;
 		displayFormat: string;
 		momentFormat: string;
-		togglePopover: ($event: ng.IAngularEvent) => void;
+		togglePopover($event: ng.IAngularEvent): void;
+		clear($event: ng.IAngularEvent): void;
 	}
 
 
@@ -126,6 +127,13 @@ module Lui.Directives {
 				}
 			};
 			$scope.popover = { isOpen: false };
+			$scope.clear = ($event: ng.IAngularEvent) => {
+				$scope.period.start = undefined;
+				$scope.period.end = undefined;
+				this.setViewValue(undefined);
+				this.closePopover();
+				$event.stopPropagation();
+			};
 		}
 		// set stuff - is called in the linq function
 		public setNgModelCtrl(ngModelCtrl: ng.INgModelController): void {
@@ -216,6 +224,7 @@ module Lui.Directives {
 				this.$scope.displayStr = this.$filter("luifFriendlyRange")(this.$scope.period);
 			} else {
 				this.$scope.period = this.getViewValue();
+				this.$scope.displayStr = "";
 			}
 			this.popoverController.close();
 		}

--- a/ts/date-picker/daterangepricker.directive.ts
+++ b/ts/date-picker/daterangepricker.directive.ts
@@ -210,6 +210,7 @@ module Lui.Directives {
 			}
 		}
 		private closePopover(): void {
+			this.$scope.direction = "";
 			if (!!this.$scope.period.start && !!this.$scope.period.end) {
 				this.setViewValue(this.$scope.period);
 				this.$scope.displayStr = this.$filter("luifFriendlyRange")(this.$scope.period);

--- a/ts/date-picker/daterangepricker.directive.ts
+++ b/ts/date-picker/daterangepricker.directive.ts
@@ -52,6 +52,8 @@ module Lui.Directives {
 		displayStr: string;
 		displayFormat: string;
 		momentFormat: string;
+		fromLabel: string;
+		toLabel: string;
 		togglePopover($event: ng.IAngularEvent): void;
 		clear($event: ng.IAngularEvent): void;
 	}
@@ -73,6 +75,17 @@ module Lui.Directives {
 			super($scope);
 			this.$scope = $scope;
 			this.$filter = $filter;
+
+			switch (moment.locale()) {
+				case "fr":
+					$scope.fromLabel = "Du";
+					$scope.toLabel = "Au";
+					break;
+				default: // en
+					$scope.fromLabel = "From";
+					$scope.toLabel = "To";
+					break;
+			}
 			$scope.selectDay = (day: CalendarDay) => {
 				if ($scope.editingStart || (!!$scope.period.start && day.date.isBefore($scope.period.start))) {
 					$scope.period.start = day.date;

--- a/ts/utils/formatter.ts
+++ b/ts/utils/formatter.ts
@@ -17,7 +17,7 @@ module Lui.Utils {
 			}
 		}
 		public formatValue(value: moment.Moment): any {
-			if (!value) { 
+			if (!value) {
 				return value;
 			}
 			switch (this.format) {

--- a/ts/utils/formatter.ts
+++ b/ts/utils/formatter.ts
@@ -17,6 +17,9 @@ module Lui.Utils {
 			}
 		}
 		public formatValue(value: moment.Moment): any {
+			if (!value) { 
+				return value;
+			}
 			switch (this.format) {
 				case "moment": return this.formatMoment(value);
 				case "date": return this.formatDate(value);


### PR DESCRIPTION
TODOs:

- [Daterange] When setting the end date first, the start date should then be selected, rather than closing the popup :white_check_mark: 
- [Daterange] Translate "From" / "To" placeholders :white_check_mark: 
- [Both] Implement the "clear input" mechanic :white_check_mark: 
- [Both] Implement shortcuts :white_check_mark: 
- [Both] Warn if displayed-months > 2 when in a popup :white_check_mark: 