### PR TITLE
Compact.focusandpickerstyle

### DIFF
--- a/demo/sass/inputs/inputs.html
+++ b/demo/sass/inputs/inputs.html
@@ -171,6 +171,13 @@
 	</div>
 </div>
 <br>
+<div class="lui field">
+	<div class="lui compact input">
+		<luid-image-picker class="compact" ng-model="image3" id="imagepicker2" delete-enabled="true"></luid-image-picker>
+		<label for="imagepicker">Image Picker</label>
+	</div>
+</div>
+<br>
 <!--moment picker-->
 <div class="lui field">
 	<div class="lui compact input">

--- a/scss/core/elements/input/_input.compact.scss
+++ b/scss/core/elements/input/_input.compact.scss
@@ -120,6 +120,7 @@
 @import "datepicker/input.datepicker.compact",
 		"iban/input.iban.compact",
 		"imagepicker/input.imagepicker.compact",
+		"checkbox.radio/input.checkbox.radio.compact",
 		"momentpicker/input.momentpicker.compact",
 		"tagged/input.tagged.compact",
 		"timespanpicker/input.timespanpicker.compact",

--- a/scss/core/elements/input/_input.compact.scss
+++ b/scss/core/elements/input/_input.compact.scss
@@ -25,6 +25,7 @@
 
 %lui_input_focus_compact {
 	background-color: luiTheme(element, field, input, compact, focus, background-color);
+	border-color: luiTheme(element, field, input, compact, focus, border-color);
 }
 
 %lui_input_invalid_input_compact {

--- a/scss/core/elements/input/checkbox.radio/_input.checkbox.radio.compact.scss
+++ b/scss/core/elements/input/checkbox.radio/_input.checkbox.radio.compact.scss
@@ -1,0 +1,13 @@
+@if luiTheme(element, field, enabled) {
+	@at-root #{$namespace} {
+		@if lui_input_style_enabled("compact") {
+			$selector: lui_input_get_style_selector("compact");
+			#{$prefix}.radio.input#{$selector},
+			#{$prefix}.checkbox.input#{$selector} {
+				label {
+					margin-right: 1em;
+				}
+			}
+		}
+	}
+}

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.compact.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.compact.scss
@@ -27,7 +27,7 @@
 
 				&:hover {
 					.luid-image-picker-picture {
-						background-color: #EFEFEF;
+						background-color: luiTheme(element, field, input, compact, focus, background-color);
 						color: #666;
 						border-color: #A6A6A6;
 					}
@@ -38,7 +38,7 @@
 					background-position: 0 0;
 					background-repeat: no-repeat;
 					background-size: contain;
-					background-color: #FAFAFA;
+					background-color: luiTheme(element, field, input, compact, background-color);
 					border: 1px dashed #DAE0E4;
 					border-radius: luiTheme(element, field, input, compact, border-radius);
 				}

--- a/scss/core/elements/input/tagged/_input.tagged.compact.scss
+++ b/scss/core/elements/input/tagged/_input.tagged.compact.scss
@@ -1,5 +1,5 @@
 %lui_tagged_input_tag_compact {
-	background-color: luiPalette(light, color, dark);
+	background-color: luiPalette(light, color, light);
 	color: luiPalette(light, text);
 
 	&:hover {

--- a/scss/themes/default/core/elements/_field.defaults.scss
+++ b/scss/themes/default/core/elements/_field.defaults.scss
@@ -56,7 +56,8 @@ $field: (
 			hover-color: 			luiPalette(light, color, dark),
 
 			focus: (
-				background-color: 	#fafafa
+				background-color: 	#fafafa,
+				border-color: luiPalette(grey, color)
 			)
 		)
 	),

--- a/ts/image-picker/image-picker.html
+++ b/ts/image-picker/image-picker.html
@@ -3,7 +3,7 @@
 	<div class="input-overlay">
 		<span class="lui capitalized sentence" translate="LUIIMGPICKER_UPLOAD_IMAGE"></span>
 		<input accept="image/*" type="file" ng-model="file" class="fileInput" file-model="image" luid-image-cropper on-cropped="onCropped" on-cancelled="onCancelled" cropping-disabled="croppingDisabled" cropping-ratio="croppingRatio"/>
-		<i ng-if="deleteEnabled" class="lui icon cross primary" ng-click="onDelete()"></i>
+		<i ng-if="deleteEnabled" class="empty" ng-click="onDelete()"></i>
 	</div>
 	<div class="upload-overlay">
 		<div class="lui inverted x-large loader"></div>


### PR DESCRIPTION
A quick fix on compact styling to add more contrast on input focus and tags. Also fixes radio label margins.
![new focus state](https://cloud.githubusercontent.com/assets/26228000/24096555/6a3bff2a-0d62-11e7-8f13-c66f9887e6d3.PNG)
![new image compact](https://cloud.githubusercontent.com/assets/26228000/24096557/6b6a8f56-0d62-11e7-8189-6a793a8debed.PNG)
![new tags](https://cloud.githubusercontent.com/assets/26228000/24096559/6ccfbc2c-0d62-11e7-9dd2-72c13f61823a.PNG)
