### PR TITLE
Issue #414 : Dropdown styles split between material and compact

### DIFF
--- a/scss/core/elements/input/_input.compact.scss
+++ b/scss/core/elements/input/_input.compact.scss
@@ -118,6 +118,7 @@
 }
 
 @import "datepicker/input.datepicker.compact",
+		"dropdown/input.dropdown.compact",
 		"iban/input.iban.compact",
 		"imagepicker/input.imagepicker.compact",
 		"checkbox.radio/input.checkbox.radio.compact",

--- a/scss/core/elements/input/_input.material.scss
+++ b/scss/core/elements/input/_input.material.scss
@@ -153,6 +153,7 @@
 }
 
 @import "checkbox.radio/input.checkbox.radio.material",
+		"dropdown/input.dropdown.material",
 		"datepicker/input.datepicker.material",
 		"iban/input.iban.material",
 		"imagepicker/input.imagepicker.material",

--- a/scss/core/elements/input/dropdown/_input.dropdown.compact.scss
+++ b/scss/core/elements/input/dropdown/_input.dropdown.compact.scss
@@ -1,0 +1,33 @@
+%lui_dropdown_list_group_compact {
+	&:not(:only-child) {
+		border-top: 1px solid luiTheme(element, field, input, compact, border-color);
+	}
+}
+
+%lui_dropdown_list_group_header_compact {
+	border-bottom: 1px dotted luiTheme(element, field, input, compact, border-color);
+}
+
+%lui_dropdown_list_item_compact {
+	&.dividing:after {
+		border-bottom: 1px solid luiTheme(element, field, input, compact, border-color);
+	}
+}
+
+@if luiTheme(element, field, dropdown, enabled) {
+	@at-root #{$namespace} {
+		@if lui_input_style_enabled("compact") {
+			$selector: lui_input_get_style_selector("compact");
+			#{$prefix}#{$selector} {
+
+				&.dropdown .dropdown-header {
+					@extend %lui_dropdown_list_group_header_compact;
+				}
+
+				&[uib-dropdown] ul li {
+					@extend %lui_dropdown_list_item_compact;
+				}
+			}
+		}
+	}
+}

--- a/scss/core/elements/input/dropdown/_input.dropdown.material.scss
+++ b/scss/core/elements/input/dropdown/_input.dropdown.material.scss
@@ -1,0 +1,33 @@
+%lui_dropdown_list_group_material {
+	&:not(:only-child) {
+		border-top: 1px solid luiTheme(element, field, input, material, default-border-color);
+	}
+}
+
+%lui_dropdown_list_group_header_material {
+	border-bottom: 1px dotted luiTheme(element, field, input, material, default-border-color);
+}
+
+%lui_dropdown_list_item_material {
+	&.dividing:after {
+		border-bottom: 1px solid luiTheme(element, field, input, material, default-border-color);
+	}
+}
+
+@if luiTheme(element, field, dropdown, enabled) {
+	@at-root #{$namespace} {
+		@if lui_input_style_enabled("material") {
+			$selector: lui_input_get_style_selector("material");
+			#{$prefix}#{$selector} {
+
+				&.dropdown .dropdown-header {
+					@extend %lui_dropdown_list_group_header_material;
+				}
+
+				&[uib-dropdown] ul li {
+					@extend %lui_dropdown_list_item_material;
+				}
+			}
+		}
+	}
+}

--- a/scss/core/elements/input/ui-select/_input.ui-select.compact.scss
+++ b/scss/core/elements/input/ui-select/_input.ui-select.compact.scss
@@ -4,6 +4,14 @@
 		@at-root #{$namespace} {
 			#{$prefix}.input#{$selector} .ui-select-container, #{$prefix}.input .ui-select-container#{$selector} {
 
+				.ui-select-choices-row {
+					@extend %lui_dropdown_list_item_compact;
+				}
+
+				.ui-select-choices-group {
+					@extend %lui_dropdown_list_group_compact;
+				}
+
 				&:not(.ui-select-multiple) {
 					.ui-select-match .ui-select-toggle,
 					.ui-select-search {

--- a/scss/core/elements/input/ui-select/_input.ui-select.material.scss
+++ b/scss/core/elements/input/ui-select/_input.ui-select.material.scss
@@ -4,6 +4,14 @@
 		@at-root #{$namespace} {
 			#{$prefix}.input#{$selector} .ui-select-container, #{$prefix}.input .ui-select-container#{$selector} {
 
+				.ui-select-choices-row {
+					@extend %lui_dropdown_list_item_material;
+				}
+
+				.ui-select-choices-group {
+					@extend %lui_dropdown_list_group_material;
+				}
+
 				.ui-select-match .ui-select-toggle,
 				.ui-select-search {
 					@extend %lui_input_reset_material;


### PR DESCRIPTION
Created specific stylesheets for dropdowns in material and compact to handle border specificity.  Kept the border definition in the common stylesheet in case of a use without using material nor compact classes.