### PR TITLE
Added space for the compact version of daterange-picker

### DIFF
--- a/scss/core/elements/input/datepicker/_input.datepicker.compact.scss
+++ b/scss/core/elements/input/datepicker/_input.datepicker.compact.scss
@@ -9,6 +9,16 @@
 				}
 			}
 
+			luid-daterange-picker#{$selector} .inputs {
+				.icon {
+					transform: translate(10%, -50%);
+				}
+
+				> input:last-of-type {
+					margin-left: 10px;
+				}
+			}
+
 			luid-daterange-picker#{$selector} .inputs > input:focus {
 				@extend %lui_input_focus_compact;
 			}


### PR DESCRIPTION
![daterangepickercompact](https://cloud.githubusercontent.com/assets/26228000/24870807/c891f726-1e17-11e7-97ad-15d620ed3356.PNG)
