### PR TITLE
Momentpicker.max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.1.6
 ### Bug fixes
+ - `luid-moment` - fix support time on multiple days - when your min = today 8AM and max = tomorrow 2AM, it was impossible to have the time 1AM tomorrow even if it was a correct time - would automatically set it to today 1AM -> invalid-min
 
 ## 3.1.5 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.5)
 ### Bug fixes


### PR DESCRIPTION
fix support time on multiple days - when your min = today 8AM and max = tomorrow 2AM, it was impossible to have the time 1AM tomorrow even if it was a correct time - would automatically set it to today 1AM -> invalid-min

--------------

the blur event of hours/mins was called and called `updateWihoutRender` with the inputed time, so it automatically recasted it to today. now we only call updateWithoutRender if the inputedTime is different than the viewValue