### PR TITLE
Luidtranslations.fix.issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 3.1.7
 ### Bug fixes
+### Changes (non-breaking)
+ - `luid-translations` now supports ng-required: ng-model.$viewValue is set to undefined when all the multilingual variables are empty
+ - added support for Lucca proprietary format in `luid-translations`
 
 ## 3.1.6 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.6)
 ### Bug fixes

--- a/demo/lucca/translations/translations.html
+++ b/demo/lucca/translations/translations.html
@@ -25,8 +25,7 @@
 	<ul class="lui unstyled">
 		<li><code>ng-model</code>: the variable to bind to</li>
 		<li><code>ng-change</code>: events to launch when the value is updated</li>
-		<!-- <li><code>ng-disabled</code>: </li> -->
-		<li><code>mode</code>: "dictionary", "|" or "pipe"</li>
+		<li><code>mode</code>: "dictionary", "|" (or "pipe"), "lucca" (for proprietary format)</li>
 	</ul>
 </p>
 <div class="lui dashed divider">
@@ -44,7 +43,7 @@
 <div class="lui block round">
 	<h5>Mode dictionary</h5>
 	<p>
-		<luid-translations ng-model="myTrads" ng-change="changed()"></luid-translations>
+		<luid-translations class="lui material" ng-model="myTrads" ng-change="changed()"></luid-translations>
 	</p>
 	<p>
 		myTrads: <code>{{myTrads}}</code>
@@ -52,13 +51,31 @@
 	<hr>
 	<h5>Mode pipe</h5>
 	<p>
-		<luid-translations ng-model="myTradsPipe" mode="|" size="x-long" ng-change="changed()"></luid-translations>
+		<luid-translations class="lui material" ng-model="myTradsPipe" mode="|" size="x-long" ng-change="changed()"></luid-translations>
 	</p>
 	<p>
 		myTradsPipe : <code>{{myTradsPipe}}</code>
 	</p>
 	<hr>
+	<h5>Mode Lucca (with ng-required=true)</h5>
+	<div class="lui columns">
+		<div class="lui column desktop-6">
+			<form name="translationform">
+				<luid-translations class="lui material" ng-model="requiredModel" ng-required="true" mode="lucca" ng-change="changed()" name="requiredtranslation"></luid-translations>
+				<small class="lui error message" ng-show="translationform.requiredtranslation.$touched && translationform.requiredtranslation.$error.required">
+					This field is required
+				</small>
+			</form>
+		</div>
+		<div class="lui column desktop-6">
+			<p><code>$error.required = {{!!translationform.requiredtranslation.$error.required ? translationform.requiredtranslation.$error.required : "undefined"}}</code></p>
+			<p><code>$valid = {{translationform.requiredtranslation.$valid}}</code></p>
+			<p><code>ng-model = {{requiredModel}}</code></p>
+		</div>
+	</div>
+	<hr>
 	<p>
 		Number of times <code>ng-change</code> has been called : <code>{{count}}</code>
 	</p>
 </div>
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/demo/lucca/translations/translations.html
+++ b/demo/lucca/translations/translations.html
@@ -78,4 +78,3 @@
 		Number of times <code>ng-change</code> has been called : <code>{{count}}</code>
 	</p>
 </div>
-<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/demo/lucca/translations/translations.js
+++ b/demo/lucca/translations/translations.js
@@ -3,7 +3,15 @@
 	angular.module("demoApp")
 	.controller("translationsCtrl", ["$scope", function($scope){
 		$scope.myTrads = {en: "some stuff", fr: "des bidules"};
+		$scope.myTradsPipe = "";
 		$scope.count = 0
+
+		$scope.requiredModel = [
+			{ id: 1, cultureCode: 1033, value: "stuff" },
+			{ id: 2, cultureCode: 1036, value: "truc" },
+			{ id: 3, cultureCode: 1034, value: "cosa" },
+		];
+
 		$scope.changed = function(){
 			$scope.count++;
 		}

--- a/js/directives/lucca/translations-input.js
+++ b/js/directives/lucca/translations-input.js
@@ -1,166 +1,146 @@
-(function(){
-	'use strict';
-		/**
-	** DEPENDENCIES
-	**  - angular translate
-	**  - underscore
-	**/
+(function () {
+	"use strict";
 
-	angular.module('lui.translate')
-	.directive('luidTranslations', ['$translate', '_', '$filter', '$timeout', function($translate, _, $filter,  $timeout){
-		function link(scope, element, attrs, ctrls){
-			var ngModelCtrl = ctrls[1];
-			var translateCtrl = ctrls[0];
+	/**
+	 ** DEPENDENCIES
+	 **  - angular translate
+	 **  - underscore
+	 **/
 
-			var cultures = ['en', 'de', 'es', 'fr', 'it', 'nl'];
-			scope.cultures = cultures;
-			// need the current culture to
-			var currentCulture = $translate.preferredLanguage() || "en";
-			scope.currentCulture = currentCulture;
+	angular.module("lui.translate")
+		.directive("luidTranslations", ["$translate", "_", "$filter", "$timeout", function ($translate, _, $filter, $timeout) {
+			function link(scope, element, attrs, ctrls) {
+				var ngModelCtrl = ctrls[1];
+				var translateCtrl = ctrls[0];
 
-			// default mode is dictionary
-			var mode = 'dictionary';
-			if(!!attrs.mode){
-				mode = scope.mode;
-			}
-			if(mode === 'dictionary' && ngModelCtrl.$viewValue !== undefined){
-				_.each(cultures, function(c){
-					scope.$watch(function () { return !!ngModelCtrl.$viewValue ? ngModelCtrl.$viewValue[c] : ngModelCtrl.$viewValue; },
-					function () { ngModelCtrl.$render(); });
-				});
-			}
+				// Available cultures
+				var cultures = ["en", "de", "es", "fr", "it", "nl"];
+				scope.cultures = cultures;
 
-			ngModelCtrl.$render = function(){
-				scope.internal = parse(ngModelCtrl.$viewValue);
-			};
-			translateCtrl.updateViewValue = function(){
-				switch(mode){
-					case "dictionary":
-						return updateDictionary(scope.internal);
-					case "|":
-					case "pipe":
-						return updatePipe(scope.internal);
-					case "[]":
-					case "brackets":
-						return updateBrackets(scope.internal);
+				scope.currentCulture = $translate.preferredLanguage() || "en";
+
+				var mode = !!attrs.mode ? attrs.mode : "dictionary";
+				if (mode === "dictionary" && ngModelCtrl.$viewValue !== undefined) {
+					_.each(cultures, function (c) {
+						scope.$watch(
+							function () { return !!ngModelCtrl.$viewValue ? ngModelCtrl.$viewValue[c] : ngModelCtrl.$viewValue; },
+							function () { ngModelCtrl.$render(); }
+						);
+					});
 				}
-			};
 
-			var parse = function (value) {
-				if (value === undefined) { return undefined;}
-				switch(mode){
-					case "dictionary":
-						return parseDictionary(value);
-					case "|":
-					case "pipe":
-						return parsePipe(value);
-					case "[]":
-					case "brackets":
-						return parseBrackets(value);
-					default:
-						return undefined;
-				}
-			};
+				ngModelCtrl.$render = function () { scope.internal = parse(ngModelCtrl.$viewValue); };
+				translateCtrl.updateViewValue = function () {
+					switch (mode) {
+						case "dictionary":
+							return updateDictionary(scope.internal);
+						case "|":
+						case "pipe":
+							return updatePipe(scope.internal);
+					}
+				};
 
-			// mode dictionary
-			var parseDictionary = function(value){
-				return _.reduce(cultures, function(memo, c){
-					memo[c] = value[c];
-					return memo;
-				}, {});
-			};
-			var updateDictionary = function(value){
-				var allEmpty = true;
-				var viewValue = {};
-				_.each(cultures, function (culture) {
-					viewValue[culture] = value[culture];
-					allEmpty &= value[culture] === undefined || value[culture] === "";
-				});
-				ngModelCtrl.$setViewValue(allEmpty ? undefined : viewValue);
-				scope.$parent.$eval(attrs.ngChange); // needs to be called manually cuz the object ref of the $viewValue didn't change
-			};
+				var parse = function (value) {
+					if (value === undefined) { return undefined; }
+					switch (mode) {
+						case "dictionary":
+							return parseDictionary(value);
+						case "|":
+						case "pipe":
+							return parsePipe(value);
+						default:
+							return undefined;
+					}
+				};
 
-			// mode pipe
-			var parsePipe = function(value){
-				// value looks like this "en:some stuff|de:|nl:|fr:des bidules|it:|es:"
-				var translations = value.split("|");
-				var result = {};
-				_.each(translations, function(t){
-					var key = t.substring(0,2);
-					var val = t.substring(3);
-					result[key] = val;
-				});
-				return _.pick(result, cultures);
-			};
-			var updatePipe = function(value) {
-				if (!_.find(cultures, function (culture) { return value[culture] !== undefined && value[culture] !== ""; })) {
-					ngModelCtrl.$setViewValue(undefined);
-				} else {
-					var newVal = _.map(cultures, function (c) {
-						if (!!value[c]) {
-							return c + ":" + value[c];
-						}
-						return c + ":";
-					}).join("|");
-					ngModelCtrl.$setViewValue(newVal);
-				}
-			};
+				// Mode dictionary
+				var parseDictionary = function (value) {
+					return _.reduce(cultures, function (memo, c) {
+						memo[c] = value[c];
+						return memo;
+					}, {});
+				};
+				var updateDictionary = function (value) {
+					var allEmpty = true;
+					var viewValue = {};
+					_.each(cultures, function (culture) {
+						viewValue[culture] = value[culture];
+						allEmpty &= value[culture] === undefined || value[culture] === "";
+					});
+					ngModelCtrl.$setViewValue(allEmpty ? undefined : viewValue);
+					scope.$parent.$eval(attrs.ngChange); // needs to be called manually cuz the object ref of the $viewValue didn't change
+				};
 
-			// mode brackets
-			var parseBrackets = function(value){
-				return {};
-			};
-
-		}
-		return{
-			require:['luidTranslations','^ngModel'],
-			controller:'luidTranslationsController',
-			scope: {
-				// disabled:'=',
-
-				mode:'@', // allowed values: "|" "pipe", "[]" "brackets", "dictionary"
-
-				size:"@", // the size of the input (short, long, x-long, fitting)
-			},
-			templateUrl:"lui/directives/luidTranslations.html",
-			restrict:'EA',
-			link:link
-		};
-	}])
-	.controller('luidTranslationsController', ['$scope', '$translate', '$timeout', function($scope, $filter, $timeout){
-		var ctrl = this;
-		/******************
-		* UPDATE          *
-		******************/
-		$scope.update = function(){
-			ctrl.updateViewValue();
-		};
-
-
-		/******************
-		* FOCUS & BLUR    *
-		******************/
-		var blurTimeout;
-		$scope.focusInput = function(){
-			if(!!blurTimeout){
-				$timeout.cancel(blurTimeout);
-				blurTimeout = undefined;
+				// Mode pipe
+				var parsePipe = function (value) {
+					// value looks like this "en:some stuff|de:|nl:|fr:des bidules|it:|es:"
+					var translations = value.split("|");
+					var result = {};
+					_.each(translations, function (t) {
+						var key = t.substring(0, 2);
+						var val = t.substring(3);
+						result[key] = val;
+					});
+					return _.pick(result, cultures);
+				};
+				var updatePipe = function (value) {
+					if (!_.find(cultures, function (culture) { return value[culture] !== undefined && value[culture] !== ""; })) {
+						ngModelCtrl.$setViewValue(undefined);
+					} else {
+						var newVal = _.map(cultures, function (c) {
+							if (!!value[c]) {
+								return c + ":" + value[c];
+							}
+							return c + ":";
+						}).join("|");
+						ngModelCtrl.$setViewValue(newVal);
+					}
+				};
 			}
-			$scope.focused = true;
-		};
-		$scope.blurInput = function(){
-			blurTimeout = $timeout(function(){
-				$scope.focused = false;
-			}, 500);
-		};
+			return {
+				require: ['luidTranslations', '^ngModel'],
+				controller: 'luidTranslationsController',
+				scope: {
+					mode: '@', // allowed values: "|" "pipe", "dictionary"
+					size: "@", // the size of the input (short, long, x-long, fitting)
+				},
+				templateUrl: "lui/directives/luidTranslations.html",
+				restrict: 'EA',
+				link: link
+			};
+		}])
+		.controller('luidTranslationsController', ['$scope', '$translate', '$timeout', function ($scope, $filter, $timeout) {
+			var ctrl = this;
+			/******************
+			* UPDATE          *
+			******************/
+			$scope.update = function () {
+				ctrl.updateViewValue();
+			};
 
-	}]);
+			/******************
+			* FOCUS & BLUR    *
+			******************/
+			var blurTimeout;
+			$scope.focusInput = function () {
+				if (!!blurTimeout) {
+					$timeout.cancel(blurTimeout);
+					blurTimeout = undefined;
+				}
+				$scope.focused = true;
+			};
+			$scope.blurInput = function () {
+				blurTimeout = $timeout(function () {
+					$scope.focused = false;
+				}, 500);
+			};
 
+		}]);
 
 	/**************************/
-	/***** TEMPLATEs      *****/
+	/***** TEMPLATES      *****/
 	/**************************/
-	angular.module("lui").run(["$templateCache", function($templateCache) {
+	angular.module("lui").run(["$templateCache", function ($templateCache) {
 		$templateCache.put("lui/directives/luidTranslations.html",
 			"<div class=\"lui dropdown {{size}} field\" ng-class=\"{open:focused || hovered}\" ng-mouseenter=\"hovered=true\" ng-mouseleave=\"hovered=false\">" +
 			"	<div class=\"lui input\">" +
@@ -174,11 +154,8 @@
 			"				<span class=\"unit addon\">{{culture}}</span>" +
 			"			</div>" +
 			"		</div>" +
-			// "		<hr>" +
-			// "		<div class=\"lui button right pulled\" ng-click=\"close()\">Ok</div>" +
 			"	</div>" +
 			"</div>" +
-		"");
-
+			"");
 	}]);
 })();

--- a/js/directives/lucca/translations-input.js
+++ b/js/directives/lucca/translations-input.js
@@ -15,16 +15,12 @@
 
 				/** Associations language/code */
 				var languagesToCodes = { en: 1033, de: 1031, es: 1034, fr: 1036, it: 1040, nl: 2067 };
-				/** Associations code/language */
-				var codesToLanguages = { 1033: "en", 1031: "de", 1034: "es", 1036: "fr", 1040: "it", 2067: "nl" };
-				/* Fallback language (sorted) */
-				var fallbackLanguages = ["en", "fr", "de", "es", "it", "nl"];
 
 				/** List of all the available languages labels */
 				var cultures = _.keys(languagesToCodes);
 				scope.cultures = cultures;
 
-				scope.currentCulture = $translate.preferredLanguage() || fallbackLanguages[0];
+				scope.currentCulture = $translate.preferredLanguage() || "en";
 
 				var mode = !!attrs.mode ? attrs.mode : "dictionary";
 				if (mode === "dictionary" && ngModelCtrl.$viewValue !== undefined) {

--- a/tests/spec/directives/translations-input.spec.js
+++ b/tests/spec/directives/translations-input.spec.js
@@ -4,7 +4,7 @@ describe('luidTranslations', function(){
 	beforeEach(module('lui'));
 	beforeEach(module('lui.translate'));
 
-	var moment, $scope, isolateScope, $compile, $filter, elt, input, ngModelCtrl;
+	var moment, $scope, isolateScope, $compile, $filter, elt, input, ngModelCtrl, _;
 	beforeEach(inject(function (_moment_, _$rootScope_, _$compile_, _$filter_) {
 		moment = _moment_;
 		$scope = _$rootScope_.$new();
@@ -83,4 +83,59 @@ describe('luidTranslations', function(){
 		});
 	});
 
+	describe("mode='lucca'", function () {
+		beforeEach(function () {
+			$scope.myTrads = [];
+			var tpl = angular.element('<luid-translations ng-model="myTrads" mode="lucca"></luid-translations>');
+			elt = $compile(tpl)($scope);
+			$scope.$digest();
+			isolateScope = elt.isolateScope();
+			ngModelCtrl = elt.controller("ngModel");
+		});
+		it("should be able to parse the lucca format", function () {
+			$scope.myTrads = [
+				{ id: 1, cultureCode: 1033, value: "stuff" },
+				{ id: 2, cultureCode: 1036, value: "truc" },
+				{ id: 3, cultureCode: 1034, value: "cosa" },
+			];
+			$scope.$digest();
+			expect(isolateScope.internal.en).toEqual("stuff");
+			expect(isolateScope.internal.fr).toEqual("truc");
+			expect(isolateScope.internal.es).toEqual("cosa");
+		});
+
+		it("should keep the original ids", function () {
+			$scope.myTrads = [
+				{ id: 1, cultureCode: 1033, value: "stuff" },
+				{ id: 2, cultureCode: 1036, value: "truc" },
+				{ id: 3, cultureCode: 1034, value: "cosa" },
+			];
+			$scope.$digest();
+			expect(isolateScope.internal.en_id).toEqual(1);
+			expect(isolateScope.internal.fr_id).toEqual(2);
+			expect(isolateScope.internal.es_id).toEqual(3);
+		});
+		it("should keep the original ids even after updating the viewModel", function(){
+			$scope.myTrads = [
+				{ id: 1, cultureCode: 1033, value: "stuff" },
+				{ id: 2, cultureCode: 1036, value: "truc" },
+				{ id: 3, cultureCode: 1034, value: "cosa" },
+			];
+			$scope.$digest();
+			isolateScope.internal.fr = "machin";
+			isolateScope.update();
+
+			// The model array is not always in the same order: loop required to find the french value
+			var found = false;
+			for (var i = 0; i < $scope.myTrads.length; i++) {
+				if ($scope.myTrads[i].cultureCode === 1036) {
+					found = true;
+					expect($scope.myTrads[i].value).toEqual("machin");
+					expect($scope.myTrads[i].id).toEqual(2);
+					break;
+				}
+			}
+			expect(found).toEqual(true);
+		});
+	});
 });


### PR DESCRIPTION
Updated the luidTranslations:
- ng-required is now supported: ng-model.$viewValue is set to undefined when all the multilingual variables are empty ;
- Added support for Lucca proprietary format.
Fixes #410 