### PR TITLE
CSS for translations-list directive

### DIFF
--- a/demo/lucca/translations-list/translations-list.html
+++ b/demo/lucca/translations-list/translations-list.html
@@ -36,9 +36,18 @@
 </div>
 <div class="lui block round">
 	<div class="lui columns">
-		<div class="lui column desktop-6">
+		<div class="lui column desktop-6" style="padding-right: 1em">
 			<p>
-				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca"></luid-translations-list>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" class="lui material"></luid-translations-list>
+			</p>
+			<p>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" class="lui compact"></luid-translations-list>
+			</p>
+			<p>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" can-edit="true" class="lui material"></luid-translations-list>
+			</p>
+			<p>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" can-edit="true" class="lui compact"></luid-translations-list>
 			</p>
 		</div>
 		<div class="lui column desktop-6" style="border-left: 1px solid rgba(50, 50, 50, 0.2)">

--- a/scss/core/elements/input/_input.common.scss
+++ b/scss/core/elements/input/_input.common.scss
@@ -161,5 +161,6 @@
 		"tagged/input.tagged.common",
 		"timespanpicker/input.timespanpicker.common",
 		"translations/input.translations.common",
+		"translations-list/input.translations-list.common",
 		"ui-select/input.ui-select.common",
 		"userpicker/input.userpicker.common";

--- a/scss/core/elements/input/_input.compact.scss
+++ b/scss/core/elements/input/_input.compact.scss
@@ -126,4 +126,5 @@
 		"tagged/input.tagged.compact",
 		"timespanpicker/input.timespanpicker.compact",
 		"translations/input.translations.compact",
+		"translations-list/input.translations-list.compact",
 		"ui-select/input.ui-select.compact";

--- a/scss/core/elements/input/_input.material.scss
+++ b/scss/core/elements/input/_input.material.scss
@@ -161,4 +161,5 @@
 		"tagged/input.tagged.material",
 		"timespanpicker/input.timespanpicker.material",
 		"translations/input.translations.material",
+		"translations-list/input.translations-list.material",
 		"ui-select/input.ui-select.material";

--- a/scss/core/elements/input/translations-list/_input.translations-list.common.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.common.scss
@@ -44,36 +44,8 @@
 
 			footer {
 				padding: .2em 0;
-				> button {
-					color: luiPalette(grey, color);
-					position: relative;
-					opacity: 1;
-					transition: opacity .15s ease-out;
-
-					&[disabled="disabled"] {
-						opacity: .4;
-						cursor: default !important;
-					}
-
-					&::after {
-						content: '';
-						position: absolute;
-						display: block;
-						left: 0;
-						right: 0;
-						bottom: -3px;
-						border-bottom: 1px solid luiPalette(grey, color);
-						opacity: 0;
-						transition: opacity .15s ease-out;
-					}
-
-					&:not[disabled="disabled"]:hover {
-						color: luiPalette(grey, color, x-dark);
-
-						&::after {
-							opacity: 1;
-						}
-					}
+				> button.lui.button {
+					margin-left: 0;
 				}
 			}
 		}

--- a/scss/core/elements/input/translations-list/_input.translations-list.common.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.common.scss
@@ -1,0 +1,81 @@
+@if luiTheme(element, field, translations, enabled) {
+	@at-root #{$namespace} {
+		$vars: luiTheme(element, field, translations-list);
+
+		luid-translations-list {
+
+			content {
+				display: block;
+				padding: 1em;
+				background-color: map-gets($vars, background-color);
+			}
+
+			#{$prefix}.input {
+				width: 100%;
+				padding: .2em 0;
+
+				> input[ng-model]:not([type="checkbox"]):not([type="radio"]):not([size]):not(luid-translations) {
+					width: auto;
+					@include flex(1);
+				}
+			}
+
+			#{$prefix}.icon.cross[class*="cross"]{
+				margin: -4px 0 0 0;
+				padding: 0;
+				height: 100%;
+
+				&:hover {
+					text-decoration: none;
+					&::before {
+						color: map-gets($vars, hover-color);
+					}
+				}
+				&::before {
+					content: "\00d7";
+					color: luiTheme(element, field, input, label, color);
+					font-size: 1.5em;
+				}
+
+				&:focus, &:active {
+					outline: none;
+				}
+			}
+
+			footer {
+				padding: .2em 0;
+				> button {
+					color: luiPalette(grey, color);
+					position: relative;
+					opacity: 1;
+					transition: opacity .15s ease-out;
+
+					&[disabled="disabled"] {
+						opacity: .4;
+						cursor: default !important;
+					}
+
+					&::after {
+						content: '';
+						position: absolute;
+						display: block;
+						left: 0;
+						right: 0;
+						bottom: -3px;
+						border-bottom: 1px solid luiPalette(grey, color);
+						opacity: 0;
+						transition: opacity .15s ease-out;
+					}
+
+					&:not[disabled="disabled"]:hover {
+						color: luiPalette(grey, color, x-dark);
+
+						&::after {
+							opacity: 1;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/scss/core/elements/input/translations-list/_input.translations-list.compact.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.compact.scss
@@ -1,0 +1,38 @@
+@if luiTheme(element, field, enabled) {
+	$vars: luiTheme(element, field, translations-list);
+	@at-root #{$namespace} {
+		@if lui_input_style_enabled("compact") {
+			$selector: lui_input_get_style_selector("compact");
+
+			#{$prefix}.input#{$selector} luid-translations-list,
+			luid-translations-list#{$selector} {
+
+				// Adapt menu style for compact
+				#{$prefix}.menu.dividing:not(.vertical):not([class*="top dividing"]) {
+					border: 0;
+					padding: 0 1.5em;
+					overflow-y: hidden;
+					background-color: map-gets($vars, menu-bg-color);
+
+					> a.item.active {
+						box-shadow: map-gets($vars, box-shadow);
+						background-color: map-gets($vars, background-color);
+					}
+					
+					> a.item::after {
+						bottom: auto;
+						top: 0;
+					}
+				}
+
+				content {
+					box-shadow: map-gets($vars, box-shadow);
+				}
+
+				input {
+					@extend %lui_quick_compact_input;
+				}
+			}
+		}
+	}
+}

--- a/scss/core/elements/input/translations-list/_input.translations-list.compact.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.compact.scss
@@ -1,6 +1,7 @@
 @if luiTheme(element, field, enabled) {
-	$vars: luiTheme(element, field, translations-list);
+
 	@at-root #{$namespace} {
+		$vars: luiTheme(element, field, translations-list);
 		@if lui_input_style_enabled("compact") {
 			$selector: lui_input_get_style_selector("compact");
 

--- a/scss/core/elements/input/translations-list/_input.translations-list.material.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.material.scss
@@ -1,0 +1,18 @@
+@if luiTheme(element, field, enabled) {
+	@at-root #{$namespace} {
+		@if lui_input_style_enabled("material") {
+			$selector: lui_input_get_style_selector("material");
+			#{$prefix}.input#{$selector} luid-translations-list,
+			luid-translations-list#{$selector} {
+
+				input {
+					@extend %lui_input_reset_material;
+
+					&:focus {
+						@extend %lui_input_focus_material;
+					}
+				}
+			}
+		}
+	}
+}

--- a/scss/core/elements/input/translations-list/_input.translations-list.material.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.material.scss
@@ -4,7 +4,13 @@
 			$selector: lui_input_get_style_selector("material");
 			#{$prefix}.input#{$selector} luid-translations-list,
 			luid-translations-list#{$selector} {
-
+				> div {
+					box-shadow: 0 0 1px 0 rgba(0, 0, 0, .4);
+				}
+				#{$prefix}.menu.dividing:not(.vertical):not([class*="top dividing"]) > a.item::after {
+					top: auto;
+					bottom: -1px;
+				}
 				input {
 					@extend %lui_input_reset_material;
 

--- a/scss/themes/default/core/elements/_field.defaults.scss
+++ b/scss/themes/default/core/elements/_field.defaults.scss
@@ -143,6 +143,13 @@ $field: (
 		enabled:				true
 	),
 
+	translations-list: (
+		hover-color:				#000,
+		menu-bg-color:				#FAFAFA,
+		background-color:				#FFF,
+		box-shadow:				0 0 3px 0 rgba(0,0,0, .2)
+	),
+
 	dropdown: (
 		enabled:				true,
 		z-index:				10

--- a/ts/translations-list/translations-list.controller.ts
+++ b/ts/translations-list/translations-list.controller.ts
@@ -60,11 +60,11 @@ module lui.translationslist {
 
 	angular.module("lui.translate").config(["$translateProvider", function ($translateProvider: ng.translate.ITranslateProvider): void {
 		$translateProvider.translations("en", {
-			"LUID_TRANSLATIONSLIST_ADD_VALUE": "New value",
+			"LUID_TRANSLATIONSLIST_ADD_VALUE": "Add new value",
 			"LUID_TRANSLATIONSLIST_INPUT_VALUE": "Input a value"
 		});
 		$translateProvider.translations("fr", {
-			"LUID_TRANSLATIONSLIST_ADD_VALUE": "Nouvelle valeur",
+			"LUID_TRANSLATIONSLIST_ADD_VALUE": "Ajouter une nouvelle valeur",
 			"LUID_TRANSLATIONSLIST_INPUT_VALUE": "Saisir une valeur"
 		});
 	}]);

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -12,7 +12,7 @@
 			</li>
 		</ul>
 		<footer ng-if="!!canEdit">
-			<button ng-click="addValue()" ng-hide="canAddValue()" class="lui button wired light animated up fade in" translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
+			<button ng-click="addValue()" ng-hide="canAddValue()" class="lui button filled animated up fade in" translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
 		</footer>
 	</content>
 

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -1,21 +1,19 @@
 <div>
-	<nav class="lui dividing primary menu">
+	<nav class="lui dividing justified primary menu">
 		<a class="lui item" ng-repeat="culture in cultures" ng-class="{ 'active': culture === selectedCulture }"
 		   ng-click="selectCulture(culture)" ng-bind-html="culture | uppercase"></a>
 	</nav>
 	<content>
-		<ul class="lui unstyled">
-			<li class="lui field container" ng-repeat="value in values[selectedCulture].values track by $index">
-				<div class="lui input animated up fade in">
+		<ul class="lui unstyled field container">
+			<li class="lui input animated left fade in" ng-repeat="value in values[selectedCulture].values track by $index">
 					<input type="text" ng-model="values[selectedCulture].values[$index].value"
 						placeholder="{{ values[currentCulture].values[$index].value || ( 'LUID_TRANSLATIONSLIST_INPUT_VALUE' | translate) }}">
-					<button class="lui flat button small icon cross close" ng-click="deleteValue($index)"></button>
-				</div>
+					<button class="lui flat button icon cross close" ng-click="deleteValue($index)" ng-if="!!canEdit"></button>
 			</li>
 		</ul>
+		<footer ng-if="!!canEdit">
+			<button ng-click="addValue()" ng-hide="canAddValue()" class="lui unstyled animated up fade in">+ {{'LUID_TRANSLATIONSLIST_ADD_VALUE' | translate}}</button>
+		</footer>
 	</content>
-	<footer>
-		<button class="lui flat button" ng-click="addValue()" ng-disabled="canAddValue()"
-				translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
-	</footer>
+
 </div>

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -12,7 +12,7 @@
 			</li>
 		</ul>
 		<footer ng-if="!!canEdit">
-			<button ng-click="addValue()" ng-hide="canAddValue()" class="lui unstyled animated up fade in">+ {{'LUID_TRANSLATIONSLIST_ADD_VALUE' | translate}}</button>
+			<button ng-click="addValue()" ng-hide="canAddValue()" class="lui button wired light animated up fade in" translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
 		</footer>
 	</content>
 


### PR DESCRIPTION
Styling for the translations-list directive, with a compact and a material variation. 
![framedtranslations](https://cloud.githubusercontent.com/assets/26228000/25345523/a389c874-2915-11e7-9fe8-2600f29aa47d.PNG)
