### PR TITLE
Luid.translations.list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 ### Bug fixes
 ### Changes (non-breaking)
  - `luid-translations` now supports ng-required: ng-model.$viewValue is set to undefined when all the multilingual variables are empty
- - added support for Lucca proprietary format in `luid-translations`
- - Added `luid-translations-list`, a directive to input multilingual lists.
+ - `luid-translations` now supports ng-disabled
+ - `luid-translations` now supports Lucca proprietary format
+ - Added `luid-translations-list`, a directive to input multilingual lists
 
 ## 3.1.6 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.6)
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes (non-breaking)
  - `luid-translations` now supports ng-required: ng-model.$viewValue is set to undefined when all the multilingual variables are empty
  - added support for Lucca proprietary format in `luid-translations`
+ - Added `luid-translations-list`, a directive to input multilingual lists.
 
 ## 3.1.6 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.6)
 ### Bug fixes

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -17,7 +17,7 @@
 		"lui.tablegrid",
 		"lui.translate",
 		"as.sortable",
-		"lui.translationslist"
+		"lui.translate"
 	]);
 
 	angular.module('demoApp')

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -17,6 +17,7 @@
 		"lui.tablegrid",
 		"lui.translate",
 		"as.sortable",
+		"lui.translationslist"
 	]);
 
 	angular.module('demoApp')

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -16,8 +16,7 @@
 		"lui.notify",
 		"lui.tablegrid",
 		"lui.translate",
-		"as.sortable",
-		"lui.translate"
+		"as.sortable"
 	]);
 
 	angular.module('demoApp')

--- a/demo/index.html
+++ b/demo/index.html
@@ -115,6 +115,7 @@
 <script type="text/javascript" src="lucca/notify/notify.js"></script>
 <script type="text/javascript" src="lucca/tablegrid/tablegrid.js"></script>
 <script type="text/javascript" src="lucca/translations/translations.js"></script>
+<script type="text/javascript" src="lucca/translations-list/translations-list.js"></script>
 <script type="text/javascript" src="lucca/userpicker/userpicker.js"></script>
 
 <!-- /form -->

--- a/demo/lucca/content.html
+++ b/demo/lucca/content.html
@@ -1,10 +1,10 @@
 <section class="lui typeset container">
-
 	<article id="redirectRequestsCtrl" ng-include="'lucca/redirect-requests/redirect-requests.html'" ng-controller="redirectRequestsCtrl"></article>
 	<article id="luid-api-select" ng-include="'lucca/apiselect/apiselect.html'" ng-controller="apiselectCtrl"></article>
 	<article id="luid-image-picker" ng-include="'lucca/imagepicker/imagepicker.html'" ng-controller="imagepickerCtrl"></article>
 	<article id="luis-notify" ng-include="'lucca/notify/notify.html'" ng-controller="notifyCtrl"></article>
 	<article id="luid-table-grid" ng-include="'lucca/tablegrid/tablegrid.html'" ng-controller="tablegridCtrl"></article>
 	<article id="luid-translations" ng-include="'lucca/translations/translations.html'" ng-controller="translationsCtrl"></article>
+	<article id="luid-translations-list" ng-include="'lucca/translations-list/translations-list.html'" ng-controller="translationsListCtrl"></article>
 	<article id="luid-user-picker" ng-include="'lucca/userpicker/userpicker.html'" ng-controller="userPickerCtrl"></article>
 </section>

--- a/demo/lucca/nav.html
+++ b/demo/lucca/nav.html
@@ -4,5 +4,6 @@
 	<a class="item" href="#/lucca#luis-notify">luis-notify</a>
 	<a class="item" href="#/lucca#luid-table-grid">luid-table-grid</a>
 	<a class="item" href="#/lucca#luid-translations">luid-translations</a>
+	<a class="item" href="#/lucca#luid-translations-list">luid-translations-list</a>
 	<a class="item" href="#/lucca#luid-user-picker">luid-user-picker</a>
 </nav>

--- a/demo/lucca/translations-list/translations-list.html
+++ b/demo/lucca/translations-list/translations-list.html
@@ -36,9 +36,18 @@
 </div>
 <div class="lui block round">
 	<div class="lui columns">
-		<div class="lui column desktop-6">
+		<div class="lui column desktop-6" style="padding-right: 1em">
 			<p>
-				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca"></luid-translations-list>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" class="lui material"></luid-translations-list>
+			</p>
+			<p>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" class="lui compact"></luid-translations-list>
+			</p>
+			<p>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" can-edit="true" class="lui material"></luid-translations-list>
+			</p>
+			<p>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" can-edit="true" class="lui compact"></luid-translations-list>
 			</p>
 		</div>
 		<div class="lui column desktop-6" style="border-left: 1px solid rgba(50, 50, 50, 0.2)">

--- a/demo/lucca/translations-list/translations-list.html
+++ b/demo/lucca/translations-list/translations-list.html
@@ -1,0 +1,52 @@
+<!-- Description -->
+<h2 class="lui divider below">luid-translations-list</h2>
+<p>An input that display and edit of a list of values translated in multiple languages.</p>
+
+<!-- Features -->
+<div class="lui dashed divider">
+	<h4 class="lui underline">Features</h4>
+</div>
+<p>This directive also inherits from the ng-model controller and can be integrated to forms like any other input. Most directives frequently used conjointly with ng-model are also useable (such as ng-change, ng-required, etc)</p>
+
+<!-- Arguments -->
+<div class="lui dashed divider">
+	<h4 class="lui underline">Arguments</h4>
+</div>
+<p>
+	<ul class="lui unstyled">
+		<li><code>ng-model</code>: the variable to bind to</li>
+		<li><code>mode</code>: "lucca" for Lucca proprietary format (more formats will eventually be handled later on)
+	</ul>
+</p>
+
+<!-- Usage -->
+<div class="lui dashed divider">
+	<h4 class="lui underline">Usage</h4>
+</div>
+<p>
+	<pre hljs no-escape language="html">&lt;luid-translations-list ng-model="myTranslatedList"&gt;&lt;luid-translations-list&gt;</pre>
+	<pre hljs no-escape language="html">&lt;luid-translations-list ng-model="myTranslatedList" ng-change="onListChanged()" ng-required="true" mode="lucca"&gt;&lt;luid-translations-list&gt;</pre>
+</p>
+
+<!-- Demo -->
+<div class="lui bottom dashed divider menu">
+	<div class="lui header vertical menu">
+		<h4 class="lui underline">Demo</h4>
+	</div>
+</div>
+<div class="lui block round">
+	<div class="lui columns">
+		<div class="lui column desktop-6">
+			<p>
+				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca"></luid-translations-list>
+			</p>
+		</div>
+		<div class="lui column desktop-6" style="border-left: 1px solid rgba(50, 50, 50, 0.2)">
+			<p>&nbsp;&nbsp;<code>ng-model:</code></p>
+			<div style="height: 400px; overflow-y: scroll;">
+				<p><pre>{{ luccaTranslations | json }}</pre></p>
+			</div>
+			<p>Number of times <code>ng-change</code> has been called : <code>{{translationsListChangedCount}}</code></p>
+		</div>
+	</div>
+</div>

--- a/demo/lucca/translations-list/translations-list.html
+++ b/demo/lucca/translations-list/translations-list.html
@@ -6,7 +6,8 @@
 <div class="lui dashed divider">
 	<h4 class="lui underline">Features</h4>
 </div>
-<p>This directive also inherits from the ng-model controller and can be integrated to forms like any other input. Most directives frequently used conjointly with ng-model are also useable (such as ng-change, ng-required, etc)</p>
+<p>This directive also inherits from the ng-model controller and can be integrated to forms like any other input. Most directives frequently used conjointly with ng-model are also useable (such as ng-change, ng-required, ng-disabled, etc)</p>
+<p>This directive is also designed to be power-user friendly: you can navigate through the values by using the Tab key and add new values with the Enter key. You can also paste values separated by line breaks. Give it a try !</p>
 
 <!-- Arguments -->
 <div class="lui dashed divider">
@@ -37,25 +38,37 @@
 <div class="lui block round">
 	<div class="lui columns">
 		<div class="lui column desktop-6" style="padding-right: 1em">
+			<div class="lui input switch">
+				<input type="checkbox" ng-true-value="false" ng-false-value="true" ng-model="listDisabled" tooltip-class="lui" tooltip-placement="top"  uib-tooltip="{{ listDisabled ? 'Disabled' : 'Enabled' }}">
+				<label for="listDisabled"><span></span></label>
+			</div>
+			<h5>Material mode</h5>
 			<p>
-				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" class="lui material"></luid-translations-list>
+				<luid-translations-list ng-disabled="listDisabled" ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" class="lui material"></luid-translations-list>
 			</p>
-			<p>
-				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" class="lui compact"></luid-translations-list>
-			</p>
-			<p>
-				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" can-edit="true" class="lui material"></luid-translations-list>
-			</p>
-			<p>
-				<luid-translations-list ng-model="luccaTranslations" ng-change="translationsListChanged()" mode="lucca" can-edit="true" class="lui compact"></luid-translations-list>
-			</p>
-		</div>
-		<div class="lui column desktop-6" style="border-left: 1px solid rgba(50, 50, 50, 0.2)">
+			<hr>
 			<p>&nbsp;&nbsp;<code>ng-model:</code></p>
 			<div style="height: 400px; overflow-y: scroll;">
 				<p><pre>{{ luccaTranslations | json }}</pre></p>
 			</div>
 			<p>Number of times <code>ng-change</code> has been called : <code>{{translationsListChangedCount}}</code></p>
+		</div>
+
+		<div class="lui column desktop-6">
+			<div class="lui input switch">
+				<input type="checkbox" ng-true-value="false" ng-false-value="true" ng-model="listDisabled2" tooltip-class="lui" tooltip-placement="top" uib-tooltip="{{ listDisabled2 ? 'Disabled' : 'Enabled' }}">
+				<label for="listDisabled2"><span></span></label>
+			</div>
+			<h5>Compact mode</h5>
+			<p>
+				<luid-translations-list ng-disabled="listDisabled2" ng-model="luccaTranslations2" ng-change="translationsListChanged2()" mode="lucca" class="lui compact"></luid-translations-list>
+			</p>
+			<hr>
+			<p>&nbsp;&nbsp;<code>ng-model:</code></p>
+			<div style="height: 400px; overflow-y: scroll;">
+				<p><pre>{{ luccaTranslations2 | json }}</pre></p>
+			</div>
+			<p>Number of times <code>ng-change</code> has been called : <code>{{translationsListChangedCount2}}</code></p>
 		</div>
 	</div>
 </div>

--- a/demo/lucca/translations-list/translations-list.js
+++ b/demo/lucca/translations-list/translations-list.js
@@ -1,0 +1,36 @@
+(function () {
+	'use strict';
+	angular.module("demoApp")
+		.controller("translationsListCtrl", ["$scope", function ($scope) {
+			$scope.translationsListChangedCount = 0;
+			$scope.translationsListChanged = function(){
+				$scope.translationsListChangedCount++;
+			}
+			$scope.luccaTranslations = [
+				{
+					id: 1,
+					culturedLabels: [
+						{ id: 1, cultureCode: 1033, value: "Hello", translationId: 1 },
+						{ id: 2, cultureCode: 1036, value: "Bonjour", translationId: 1 },
+						{ id: 3, cultureCode: 1034, value: "Hola", translationId: 1 },
+					]
+				},
+				{
+					id: 2,
+					culturedLabels: [
+						{ id: 4, cultureCode: 1033, value: "Thanks", translationId: 2 },
+						{ id: 5, cultureCode: 1036, value: "Merci", translationId: 2 },
+						{ id: 6, cultureCode: 1034, value: "Gracias", translationId: 2 }
+					]
+				},
+				{
+					id: 3,
+					culturedLabels: [
+						{ id: 7, cultureCode: 1033, value: "Goodbye", translationId: 3 },
+						{ id: 8, cultureCode: 1036, value: "Au revoir", translationId: 3 },
+						{ id: 8, cultureCode: 1034, value: "Adios", translationId: 3 },
+					]
+				},
+			]
+		}]);
+})();

--- a/demo/lucca/translations-list/translations-list.js
+++ b/demo/lucca/translations-list/translations-list.js
@@ -3,7 +3,8 @@
 	angular.module("demoApp")
 		.controller("translationsListCtrl", ["$scope", function ($scope) {
 			$scope.translationsListChangedCount = 0;
-			$scope.translationsListChanged = function(){
+			$scope.listDisabled = false;
+			$scope.translationsListChanged = function () {
 				$scope.translationsListChangedCount++;
 			}
 			$scope.luccaTranslations = [
@@ -31,6 +32,36 @@
 						{ id: 8, cultureCode: 1034, value: "Adios", translationId: 3 },
 					]
 				},
-			]
+			];
+
+			$scope.translationsListChangedCount2 = 0;
+			$scope.listDisabled2 = false;
+			$scope.translationsListChanged2 = function () { $scope.translationsListChangedCount2++; }
+			$scope.luccaTranslations2 = [
+				{
+					id: 1,
+					culturedLabels: [
+						{ id: 1, cultureCode: 1033, value: "Hello", translationId: 1 },
+						{ id: 2, cultureCode: 1036, value: "Bonjour", translationId: 1 },
+						{ id: 3, cultureCode: 1034, value: "Hola", translationId: 1 },
+					]
+				},
+				{
+					id: 2,
+					culturedLabels: [
+						{ id: 4, cultureCode: 1033, value: "Thanks", translationId: 2 },
+						{ id: 5, cultureCode: 1036, value: "Merci", translationId: 2 },
+						{ id: 6, cultureCode: 1034, value: "Gracias", translationId: 2 }
+					]
+				},
+				{
+					id: 3,
+					culturedLabels: [
+						{ id: 7, cultureCode: 1033, value: "Goodbye", translationId: 3 },
+						{ id: 8, cultureCode: 1036, value: "Au revoir", translationId: 3 },
+						{ id: 8, cultureCode: 1034, value: "Adios", translationId: 3 },
+					]
+				},
+			];
 		}]);
 })();

--- a/demo/lucca/translations/translations.html
+++ b/demo/lucca/translations/translations.html
@@ -57,11 +57,17 @@
 		myTradsPipe : <code>{{myTradsPipe}}</code>
 	</p>
 	<hr>
-	<h5>Mode Lucca (with ng-required=true)</h5>
+	<h5>Mode Lucca (with ng-required=true and compact style)</h5>
 	<div class="lui columns">
 		<div class="lui column desktop-6">
+			<div class="lui input switch">
+				<input type="checkbox" ng-true-value="false" ng-false-value="true" ng-model="translationDisabled" tooltip-class="lui" tooltip-placement="top" uib-tooltip="{{ listDisabled2 ? 'Disabled' : 'Enabled' }}">
+				<label for="translationDisabled"><span></span></label>
+			</div>
+			<br>
+			<br>
 			<form name="translationform">
-				<luid-translations class="lui material" ng-model="requiredModel" ng-required="true" mode="lucca" ng-change="changed()" name="requiredtranslation"></luid-translations>
+				<luid-translations class="lui compact" ng-model="requiredModel" ng-disabled="translationDisabled" ng-required="true" mode="lucca" ng-change="changed()" name="requiredtranslation"></luid-translations>
 				<small class="lui error message" ng-show="translationform.requiredtranslation.$touched && translationform.requiredtranslation.$error.required">
 					This field is required
 				</small>

--- a/demo/lucca/translations/translations.js
+++ b/demo/lucca/translations/translations.js
@@ -12,6 +12,8 @@
 			{ id: 3, cultureCode: 1034, value: "cosa" },
 		];
 
+		$scope.translationDisabled = false;
+
 		$scope.changed = function(){
 			$scope.count++;
 		}

--- a/js/directives/lucca/translations-input.js
+++ b/js/directives/lucca/translations-input.js
@@ -133,7 +133,7 @@
 				scope: {
 					mode: '@', // allowed values: "pipe" (or "|"), "dictionary", "lucca" (lucca proprietary format)
 					size: "@", // the size of the input (short, long, x-long, fitting)
-					disabled: "=ngDisabled"
+					isDisabled: "=ngDisabled"
 				},
 				templateUrl: "lui/directives/luidTranslations.html",
 				restrict: 'EA',
@@ -173,13 +173,13 @@
 		$templateCache.put("lui/directives/luidTranslations.html",
 			"<div class=\"lui dropdown {{size}} field\" ng-class=\"{open:focused || hovered}\" ng-mouseenter=\"hovered=true\" ng-mouseleave=\"hovered=false\">" +
 			"	<div class=\"lui input\">" +
-			"		<input type=\"text\" ng-disabled=\"disabled\" ng-model=\"internal[currentCulture]\" ng-focus=\"focusInput()\" ng-blur=\"blurInput()\" ng-change=\"update()\">" +
+			"		<input type=\"text\" ng-disabled=\"isDisabled\" ng-model=\"internal[currentCulture]\" ng-focus=\"focusInput()\" ng-blur=\"blurInput()\" ng-change=\"update()\">" +
 			"		<span class=\"unit\">{{currentCulture}}</span>" +
 			"	</div>" +
 			"	<div class=\"dropdown-menu\">" +
 			"		<div class=\"lui {{size}} field\" ng-repeat=\"culture in cultures\" ng-if=\"culture !== currentCulture\">" +
 			"			<div class=\"lui input\">" +
-			"				<input type=\"text\" ng-disabled=\"disabled\" ng-model=\"internal[culture]\" ng-focus=\"focusInput()\" ng-blur=\"blurInput()\" ng-change=\"update()\">" +
+			"				<input type=\"text\" ng-disabled=\"isDisabled\" ng-model=\"internal[culture]\" ng-focus=\"focusInput()\" ng-blur=\"blurInput()\" ng-change=\"update()\">" +
 			"				<span class=\"unit addon\">{{culture}}</span>" +
 			"			</div>" +
 			"		</div>" +

--- a/js/directives/lucca/translations-input.js
+++ b/js/directives/lucca/translations-input.js
@@ -133,6 +133,7 @@
 				scope: {
 					mode: '@', // allowed values: "pipe" (or "|"), "dictionary", "lucca" (lucca proprietary format)
 					size: "@", // the size of the input (short, long, x-long, fitting)
+					disabled: "=ngDisabled"
 				},
 				templateUrl: "lui/directives/luidTranslations.html",
 				restrict: 'EA',
@@ -172,13 +173,13 @@
 		$templateCache.put("lui/directives/luidTranslations.html",
 			"<div class=\"lui dropdown {{size}} field\" ng-class=\"{open:focused || hovered}\" ng-mouseenter=\"hovered=true\" ng-mouseleave=\"hovered=false\">" +
 			"	<div class=\"lui input\">" +
-			"		<input type=\"text\" ng-model=\"internal[currentCulture]\" ng-focus=\"focusInput()\" ng-blur=\"blurInput()\" ng-change=\"update()\">" +
+			"		<input type=\"text\" ng-disabled=\"disabled\" ng-model=\"internal[currentCulture]\" ng-focus=\"focusInput()\" ng-blur=\"blurInput()\" ng-change=\"update()\">" +
 			"		<span class=\"unit\">{{currentCulture}}</span>" +
 			"	</div>" +
 			"	<div class=\"dropdown-menu\">" +
 			"		<div class=\"lui {{size}} field\" ng-repeat=\"culture in cultures\" ng-if=\"culture !== currentCulture\">" +
 			"			<div class=\"lui input\">" +
-			"				<input type=\"text\" ng-model=\"internal[culture]\" ng-focus=\"focusInput()\" ng-blur=\"blurInput()\" ng-change=\"update()\">" +
+			"				<input type=\"text\" ng-disabled=\"disabled\" ng-model=\"internal[culture]\" ng-focus=\"focusInput()\" ng-blur=\"blurInput()\" ng-change=\"update()\">" +
 			"				<span class=\"unit addon\">{{culture}}</span>" +
 			"			</div>" +
 			"		</div>" +

--- a/scss/core/elements/input/_input.common.scss
+++ b/scss/core/elements/input/_input.common.scss
@@ -161,5 +161,6 @@
 		"tagged/input.tagged.common",
 		"timespanpicker/input.timespanpicker.common",
 		"translations/input.translations.common",
+		"translations-list/input.translations-list.common",
 		"ui-select/input.ui-select.common",
 		"userpicker/input.userpicker.common";

--- a/scss/core/elements/input/_input.compact.scss
+++ b/scss/core/elements/input/_input.compact.scss
@@ -126,4 +126,5 @@
 		"tagged/input.tagged.compact",
 		"timespanpicker/input.timespanpicker.compact",
 		"translations/input.translations.compact",
+		"translations-list/input.translations-list.compact",
 		"ui-select/input.ui-select.compact";

--- a/scss/core/elements/input/_input.material.scss
+++ b/scss/core/elements/input/_input.material.scss
@@ -161,4 +161,5 @@
 		"tagged/input.tagged.material",
 		"timespanpicker/input.timespanpicker.material",
 		"translations/input.translations.material",
+		"translations-list/input.translations-list.material",
 		"ui-select/input.ui-select.material";

--- a/scss/core/elements/input/translations-list/_input.translations-list.common.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.common.scss
@@ -1,0 +1,53 @@
+@if luiTheme(element, field, translations, enabled) {
+	@at-root #{$namespace} {
+		$vars: luiTheme(element, field, translations-list);
+
+		luid-translations-list {
+
+			content {
+				display: block;
+				padding: 1em;
+				background-color: map-gets($vars, background-color);
+			}
+
+			#{$prefix}.input {
+				width: 100%;
+				padding: .2em 0;
+
+				> input[ng-model]:not([type="checkbox"]):not([type="radio"]):not([size]):not(luid-translations) {
+					width: auto;
+					@include flex(1);
+				}
+			}
+
+			#{$prefix}.icon.cross[class*="cross"]{
+				margin: -4px 0 0 0;
+				padding: 0;
+				height: 100%;
+
+				&:hover {
+					text-decoration: none;
+					&::before {
+						color: map-gets($vars, hover-color);
+					}
+				}
+				&::before {
+					content: "\00d7";
+					color: luiTheme(element, field, input, label, color);
+					font-size: 1.5em;
+				}
+
+				&:focus, &:active {
+					outline: none;
+				}
+			}
+
+			footer {
+				padding: .2em 0;
+				> button.lui.button {
+					margin-left: 0;
+				}
+			}
+		}
+	}
+}

--- a/scss/core/elements/input/translations-list/_input.translations-list.compact.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.compact.scss
@@ -1,0 +1,39 @@
+@if luiTheme(element, field, enabled) {
+
+	@at-root #{$namespace} {
+		$vars: luiTheme(element, field, translations-list);
+		@if lui_input_style_enabled("compact") {
+			$selector: lui_input_get_style_selector("compact");
+
+			#{$prefix}.input#{$selector} luid-translations-list,
+			luid-translations-list#{$selector} {
+
+				// Adapt menu style for compact
+				#{$prefix}.menu.dividing:not(.vertical):not([class*="top dividing"]) {
+					border: 0;
+					padding: 0 1.5em;
+					overflow-y: hidden;
+					background-color: map-gets($vars, menu-bg-color);
+
+					> a.item.active {
+						box-shadow: map-gets($vars, box-shadow);
+						background-color: map-gets($vars, background-color);
+					}
+					
+					> a.item::after {
+						bottom: auto;
+						top: 0;
+					}
+				}
+
+				content {
+					box-shadow: map-gets($vars, box-shadow);
+				}
+
+				input {
+					@extend %lui_quick_compact_input;
+				}
+			}
+		}
+	}
+}

--- a/scss/core/elements/input/translations-list/_input.translations-list.material.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.material.scss
@@ -1,0 +1,24 @@
+@if luiTheme(element, field, enabled) {
+	@at-root #{$namespace} {
+		@if lui_input_style_enabled("material") {
+			$selector: lui_input_get_style_selector("material");
+			#{$prefix}.input#{$selector} luid-translations-list,
+			luid-translations-list#{$selector} {
+				> div {
+					box-shadow: 0 0 1px 0 rgba(0, 0, 0, .4);
+				}
+				#{$prefix}.menu.dividing:not(.vertical):not([class*="top dividing"]) > a.item::after {
+					top: auto;
+					bottom: -1px;
+				}
+				input {
+					@extend %lui_input_reset_material;
+
+					&:focus {
+						@extend %lui_input_focus_material;
+					}
+				}
+			}
+		}
+	}
+}

--- a/scss/themes/default/core/elements/_field.defaults.scss
+++ b/scss/themes/default/core/elements/_field.defaults.scss
@@ -143,6 +143,13 @@ $field: (
 		enabled:				true
 	),
 
+	translations-list: (
+		hover-color:				#000,
+		menu-bg-color:				#FAFAFA,
+		background-color:				#FFF,
+		box-shadow:				0 0 3px 0 rgba(0,0,0, .2)
+	),
+
 	dropdown: (
 		enabled:				true,
 		z-index:				10

--- a/ts/modules.ts
+++ b/ts/modules.ts
@@ -13,5 +13,5 @@ module lui {
 	angular.module("lui.crop", ["lui", "lui.translate", "ngImgCrop"]);
 	angular.module("lui.iban", ["lui", "iban"]);
 	angular.module("lui.tablegrid", ["lui", "lui.translate"]);
-
+	angular.module("lui.translationslist", ["lui", "lui.translate"]);
 }

--- a/ts/modules.ts
+++ b/ts/modules.ts
@@ -13,5 +13,4 @@ module lui {
 	angular.module("lui.crop", ["lui", "lui.translate", "ngImgCrop"]);
 	angular.module("lui.iban", ["lui", "iban"]);
 	angular.module("lui.tablegrid", ["lui", "lui.translate"]);
-	angular.module("lui.translationslist", ["lui", "lui.translate"]);
 }

--- a/ts/translations-list/translations-list.class.ts
+++ b/ts/translations-list/translations-list.class.ts
@@ -1,4 +1,4 @@
-module lui.translationslist {
+module lui.translate {
 	"use strict";
 
 	/** All the languages supported by the translation-list directive */

--- a/ts/translations-list/translations-list.class.ts
+++ b/ts/translations-list/translations-list.class.ts
@@ -1,0 +1,46 @@
+module lui.translationslist {
+	"use strict";
+
+	/** All the languages supported by the translation-list directive */
+	export const AVAILABLE_LANGUAGES = ["en", "fr", "de", "es", "it", "nl"];
+	/** Used to convert languages labels to their associated culture codes */
+	export const LANGUAGES_TO_CODE = { en: 1033, de: 1031, es: 1034, fr: 1036, it: 1040, nl: 2067 };
+	/** Used to converted culture codes to their associated labels  */
+	export const CODES_TO_LANGUAGES = { 1033: "en", 1031: "de", 1034: "es", 1036: "fr", 1040: "it", 2067: "nl" };
+
+	export class CulturedList {
+		public culture: string;
+		public originalId: number;
+		public values: ICulturedValue[];
+
+		constructor(culture: string) {
+			this.culture = culture;
+			this.originalId = undefined;
+			this.values = new Array<ICulturedValue>();
+		}
+	}
+
+	export interface ICulturedValue {
+		value: string;
+		originalLuccaCulturedLabelId?: number;
+		originalLuccaTranslationId?: number;
+	}
+
+	//
+	// Lucca Format
+	//
+
+	/** Represents the Lucca proprietary format */
+	export interface ILuccaTranslation {
+		id: number;
+		culturedLabels: ILuccaCulturedLabel[];
+	}
+
+	/** Represents an entry of the Lucca proprietary format */
+	export interface ILuccaCulturedLabel {
+		id: number;
+		cultureCode: number;
+		value: string;
+		translationId: number;
+	}
+}

--- a/ts/translations-list/translations-list.controller.ts
+++ b/ts/translations-list/translations-list.controller.ts
@@ -6,14 +6,16 @@ module lui.translationslist {
 
 		public static $inject: string[] = [
 			"$scope",
-			"$translate"
+			"$translate",
+			"$timeout"
 		];
 
 		private $scope: ILuidTranslationsListScope;
 
 		constructor(
 			$scope: ILuidTranslationsListScope,
-			$translate: ng.translate.ITranslateService) {
+			$translate: ng.translate.ITranslateService,
+			$timeout: ng.ITimeoutService) {
 
 			this.$scope = $scope;
 			$scope.currentCulture = $translate.preferredLanguage();
@@ -48,11 +50,59 @@ module lui.translationslist {
 				}
 			};
 
-			$scope.canAddValue = (): boolean => {
+			$scope.isAddValueDisabled = (): boolean => {
 				return !_.some(AVAILABLE_LANGUAGES, (culture: string) => {
 					let current = this.$scope.values[culture].values;
 					return current[current.length - 1].value !== "";
 				});
+			};
+
+			$scope.onPaste = (event: ClipboardEvent, index: number): void => {
+				// Don't do anything if the directive is disabled
+				if ($scope.disabled) { return; }
+
+				let values = _.reject(event.clipboardData.getData("text/plain").split("\r\n"), (value: string) => value === "");
+				if (values.length <= 1) { return; }
+
+				// If the first item in the selectedCulture isn't empty, simply paste the first value inside it
+				if ($scope.values[$scope.selectedCulture].values[index] !== undefined) {
+					$scope.values[$scope.selectedCulture].values[index].value += values[0];
+					values.splice(0, 1);
+					++index;
+				}
+
+				_.each(AVAILABLE_LANGUAGES, (culture: string) => {
+					for (let i = 0; i < values.length; ++i) {
+						if ($scope.values[culture].values[i + index] !== undefined) {
+							$scope.values[culture].values[i + index].value = culture === $scope.selectedCulture ? values[i] : "";
+						} else {
+							$scope.values[culture].values.splice(i + index, 0, <ICulturedValue>{ value: culture === $scope.selectedCulture ? values[i] : "" });
+						}
+					}
+				});
+
+				(<HTMLInputElement>event.target).blur();
+			};
+			$scope.addValueOnEnter = {
+				"13": ($event: any): void => {
+					// The index is stored in the target's id (not very pretty ikr)
+					let index = Number($event.target.id.split("_")[1]);
+					if (index === $scope.values[$scope.selectedCulture].values.length - 1) {
+						if (!$scope.isAddValueDisabled()) {
+							// Add a value
+							index++;
+							$scope.addValue();
+							$scope.$apply();
+							$timeout(() => {
+								document.getElementById($scope.selectedCulture + "_" + index).focus();
+							});
+						}
+					} else {
+						index++;
+						document.getElementById($scope.selectedCulture + "_" + index).focus();
+						$scope.$apply();
+					}
+				}
 			};
 		}
 	}

--- a/ts/translations-list/translations-list.controller.ts
+++ b/ts/translations-list/translations-list.controller.ts
@@ -60,11 +60,11 @@ module lui.translationslist {
 
 	angular.module("lui.translate").config(["$translateProvider", function ($translateProvider: ng.translate.ITranslateProvider): void {
 		$translateProvider.translations("en", {
-			"LUID_TRANSLATIONSLIST_ADD_VALUE": "New value",
+			"LUID_TRANSLATIONSLIST_ADD_VALUE": "Add new value",
 			"LUID_TRANSLATIONSLIST_INPUT_VALUE": "Input a value"
 		});
 		$translateProvider.translations("fr", {
-			"LUID_TRANSLATIONSLIST_ADD_VALUE": "Nouvelle valeur",
+			"LUID_TRANSLATIONSLIST_ADD_VALUE": "Ajouter une nouvelle valeur",
 			"LUID_TRANSLATIONSLIST_INPUT_VALUE": "Saisir une valeur"
 		});
 	}]);

--- a/ts/translations-list/translations-list.controller.ts
+++ b/ts/translations-list/translations-list.controller.ts
@@ -1,0 +1,71 @@
+module lui.translationslist {
+	"use strict";
+
+	export class LuidTranslationsListController {
+		public static IID: string = "luidTranslationsList";
+
+		public static $inject: string[] = [
+			"$scope",
+			"$translate"
+		];
+
+		private $scope: ILuidTranslationsListScope;
+
+		constructor(
+			$scope: ILuidTranslationsListScope,
+			$translate: ng.translate.ITranslateService) {
+
+			this.$scope = $scope;
+			$scope.currentCulture = $translate.preferredLanguage();
+			if (!$scope.currentCulture) { $scope.currentCulture = "en"; }
+
+			$scope.cultures = AVAILABLE_LANGUAGES;
+			let currentCultureIndex = _.indexOf($scope.cultures, $scope.currentCulture);
+			if (currentCultureIndex !== -1) {
+				$scope.cultures.splice(currentCultureIndex, 1);
+				$scope.cultures.unshift($scope.currentCulture);
+			}
+			$scope.selectedCulture = $scope.currentCulture;
+
+			$scope.values = {};
+
+			$scope.selectCulture = (culture: string): void => { $scope.selectedCulture = culture; };
+
+			$scope.addValue = (): void => {
+				_.each(AVAILABLE_LANGUAGES, (culture: string) => {
+					$scope.values[culture].values.push(<ICulturedValue>{ value: "" });
+				});
+			};
+
+			$scope.deleteValue = (index: number): void => {
+				_.each(AVAILABLE_LANGUAGES, (culture: string) => {
+					$scope.values[culture].values.splice(index, 1);
+				});
+				if ($scope.values[AVAILABLE_LANGUAGES[0]].values.length === 0) {
+					_.each(AVAILABLE_LANGUAGES, (culture: string) => {
+						$scope.values[culture].values.push(<ICulturedValue>{ value: "" });
+					});
+				}
+			};
+
+			$scope.canAddValue = (): boolean => {
+				return !_.some(AVAILABLE_LANGUAGES, (culture: string) => {
+					let current = this.$scope.values[culture].values;
+					return current[current.length - 1].value !== "";
+				});
+			};
+		}
+	}
+	angular.module("lui").controller(LuidTranslationsListController.IID, LuidTranslationsListController);
+
+	angular.module("lui.translate").config(["$translateProvider", function ($translateProvider: ng.translate.ITranslateProvider): void {
+		$translateProvider.translations("en", {
+			"LUID_TRANSLATIONSLIST_ADD_VALUE": "New value",
+			"LUID_TRANSLATIONSLIST_INPUT_VALUE": "Input a value"
+		});
+		$translateProvider.translations("fr", {
+			"LUID_TRANSLATIONSLIST_ADD_VALUE": "Nouvelle valeur",
+			"LUID_TRANSLATIONSLIST_INPUT_VALUE": "Saisir une valeur"
+		});
+	}]);
+}

--- a/ts/translations-list/translations-list.controller.ts
+++ b/ts/translations-list/translations-list.controller.ts
@@ -1,4 +1,4 @@
-module lui.translationslist {
+module lui.translate {
 	"use strict";
 
 	export class LuidTranslationsListController {
@@ -59,7 +59,7 @@ module lui.translationslist {
 
 			$scope.onPaste = (event: ClipboardEvent, index: number): void => {
 				// Don't do anything if the directive is disabled
-				if ($scope.disabled) { return; }
+				if ($scope.isDisabled) { return; }
 
 				let values = _.reject(event.clipboardData.getData("text/plain").split("\r\n"), (value: string) => value === "");
 				if (values.length <= 1) { return; }
@@ -83,6 +83,7 @@ module lui.translationslist {
 
 				(<HTMLInputElement>event.target).blur();
 			};
+
 			$scope.addValueOnEnter = {
 				"13": ($event: any): void => {
 					// The index is stored in the target's id (not very pretty ikr)
@@ -104,9 +105,19 @@ module lui.translationslist {
 					}
 				}
 			};
+
+			$scope.getPlaceholder = (culture: string, index: number): string => {
+				let selectedCultureValue = $scope.values[$scope.selectedCulture].values[index].value;
+				if (!!selectedCultureValue) {
+					return selectedCultureValue;
+				}
+
+				let currentCultureValue = $scope.values[$scope.currentCulture].values[index].value;
+				return $scope.isDisabled ? "" : (!!currentCultureValue ? currentCultureValue : $translate.instant("LUID_TRANSLATIONSLIST_INPUT_VALUE"));
+			};
 		}
 	}
-	angular.module("lui").controller(LuidTranslationsListController.IID, LuidTranslationsListController);
+	angular.module("lui.translate").controller(LuidTranslationsListController.IID, LuidTranslationsListController);
 
 	angular.module("lui.translate").config(["$translateProvider", function ($translateProvider: ng.translate.ITranslateProvider): void {
 		$translateProvider.translations("en", {

--- a/ts/translations-list/translations-list.directive.ts
+++ b/ts/translations-list/translations-list.directive.ts
@@ -1,0 +1,147 @@
+module lui.translationslist {
+	"use strict";
+
+	class LuidTranslationsList implements angular.IDirective {
+		public static IID: string = "luidTranslationsList";
+		public restrict: string = "E";
+		public templateUrl: string = "lui/templates/translations-list/translations-list.html";
+
+		public require: string[] = ["ngModel", LuidTranslationsList.IID];
+		public scope = {
+			mode: "@", // Allowed values: "lucca"
+		};
+
+		public controller: string = LuidTranslationsListController.IID;
+
+		public static factory(): angular.IDirectiveFactory {
+			return () => { return new LuidTranslationsList(); };
+		}
+
+		private static toModel(viewModel: _.Dictionary<CulturedList>, mode: string): any {
+			let result: any;
+			switch (mode) {
+				case "lucca":
+					result = LuidTranslationsList.toLuccaModel(viewModel);
+					break;
+				default:
+					result = undefined;
+			}
+			return result;
+		}
+
+		/** Converts a dictionary of cultured list into an array of ILuccaTranslation objects */
+		private static toLuccaModel(viewModel: _.Dictionary<CulturedList>): ILuccaTranslation[] {
+			let result = new Array<ILuccaTranslation>();
+			let numberOfTranslations = -1;
+			let filledLanguages = _.filter(AVAILABLE_LANGUAGES, (language: string) => {
+				if (viewModel[language].values.length > numberOfTranslations) {
+					numberOfTranslations = viewModel[language].values.length;
+				}
+				// Only parse the languages which contain non empty values
+				return _.some(viewModel[language].values, (label: ICulturedValue) => { return label.value !== ""; });
+			});
+
+			// If everything is empty return undefined instead (usefull to support ng-required)
+			if (filledLanguages.length === 0) { return undefined; }
+
+			for (let i = 0; i < numberOfTranslations; ++i) {
+				result.push(<ILuccaTranslation>{ id: undefined, culturedLabels: new Array<ILuccaCulturedLabel>() });
+			}
+			let currentIndex = 0;
+			_.each(result, (translation: ILuccaTranslation) => {
+				_.each(filledLanguages, (language: string) => {
+					if (viewModel[language].values[currentIndex].value !== "") {
+						let vmLabel = viewModel[language].values[currentIndex];
+						translation.culturedLabels.push(<ILuccaCulturedLabel>{
+							id: vmLabel.originalLuccaCulturedLabelId, translationId: vmLabel.originalLuccaTranslationId,
+							cultureCode: LANGUAGES_TO_CODE[language],
+							value: vmLabel.value
+						});
+						if (!translation.id && !!vmLabel.originalLuccaTranslationId) {
+							translation.id = vmLabel.originalLuccaTranslationId;
+						}
+					}
+				});
+				++currentIndex;
+			});
+
+			result = _.reject(result, (translation: ILuccaTranslation) => { return translation.culturedLabels.length === 0; });
+
+			return result;
+		}
+
+		/** Parses the value given to the directive via ng-model and convert it into an object comprehensible by the controller */
+		private static parse(value: any, mode: string): _.Dictionary<CulturedList> {
+			let result: _.Dictionary<CulturedList>;
+			switch (mode) {
+				case "lucca":
+					result = LuidTranslationsList.parseLucca(<ILuccaTranslation[]>value);
+					break;
+				default:
+					result = undefined;
+					break;
+			}
+			return result;
+		}
+
+		/** Parses a model which uses the Lucca proprietary format */
+		private static parseLucca(value: ILuccaTranslation[]): _.Dictionary<CulturedList> {
+			let result: _.Dictionary<CulturedList> = LuidTranslationsList.getEmptyCulturedLists();
+
+			_.each(value, (translation: ILuccaTranslation) => {
+				_.each(translation.culturedLabels, (label: ILuccaCulturedLabel) => {
+					let language = CODES_TO_LANGUAGES[label.cultureCode];
+					result[language].values.push(<ICulturedValue>{
+						value: label.value,
+						originalLuccaCulturedLabelId: label.id,
+						originalLuccaTranslationId: label.translationId
+					});
+				});
+				// blanks ?
+				if (translation.culturedLabels.length > 0) {
+					let count = result[CODES_TO_LANGUAGES[translation.culturedLabels[0].cultureCode]].values.length;
+					_.each(AVAILABLE_LANGUAGES, (language: string) => {
+						if (result[language].values.length !== count) {
+							result[language].values.push(<ICulturedValue>{ value: "" });
+						}
+					});
+				}
+			});
+
+			return result;
+		}
+
+		/** Creates a new empty dictionary of CulturedList objects */
+		private static getEmptyCulturedLists(): _.Dictionary<CulturedList> {
+			let result: _.Dictionary<CulturedList> = {};
+			_.each(AVAILABLE_LANGUAGES, (culture: string) => {
+				result[culture] = new CulturedList(culture);
+			});
+			return result;
+		}
+
+		public link(
+			scope: ILuidTranslationsListScope,
+			element: angular.IAugmentedJQuery,
+			attrs: angular.IAttributes & { mode: string },
+			ctrls: [ng.INgModelController, LuidTranslationsListController]): void {
+
+			let ngModelCtrl = ctrls[0];
+
+			let mode = attrs.mode;
+			if (!mode) { mode = "lucca"; }
+
+			ngModelCtrl.$render = (): void => {
+				let viewModel = LuidTranslationsList.parse(ngModelCtrl.$viewValue, mode);
+				if (!!viewModel) {
+					scope.values = viewModel;
+				}
+			};
+
+			scope.$watch("values", (): void => {
+				ngModelCtrl.$setViewValue(LuidTranslationsList.toModel(scope.values, mode));
+			}, true);
+		}
+	}
+	angular.module("lui.translationslist").directive(LuidTranslationsList.IID, LuidTranslationsList.factory());
+}

--- a/ts/translations-list/translations-list.directive.ts
+++ b/ts/translations-list/translations-list.directive.ts
@@ -8,7 +8,8 @@ module lui.translationslist {
 
 		public require: string[] = ["ngModel", LuidTranslationsList.IID];
 		public scope = {
-			mode: "@", // Allowed values: "lucca"
+			mode: "@", // Allowed values: "lucca",
+			disabled: "=ngDisabled", // enable editing
 		};
 
 		public controller: string = LuidTranslationsListController.IID;
@@ -20,11 +21,8 @@ module lui.translationslist {
 		private static toModel(viewModel: _.Dictionary<CulturedList>, mode: string): any {
 			let result: any;
 			switch (mode) {
-				case "lucca":
-					result = LuidTranslationsList.toLuccaModel(viewModel);
-					break;
-				default:
-					result = undefined;
+				case "lucca": result = LuidTranslationsList.toLuccaModel(viewModel); break;
+				default: result = undefined; break;
 			}
 			return result;
 		}
@@ -74,12 +72,8 @@ module lui.translationslist {
 		private static parse(value: any, mode: string): _.Dictionary<CulturedList> {
 			let result: _.Dictionary<CulturedList>;
 			switch (mode) {
-				case "lucca":
-					result = LuidTranslationsList.parseLucca(<ILuccaTranslation[]>value);
-					break;
-				default:
-					result = undefined;
-					break;
+				case "lucca": result = LuidTranslationsList.parseLucca(<ILuccaTranslation[]>value); break;
+				default: result = undefined; break;
 			}
 			return result;
 		}
@@ -114,16 +108,14 @@ module lui.translationslist {
 		/** Creates a new empty dictionary of CulturedList objects */
 		private static getEmptyCulturedLists(): _.Dictionary<CulturedList> {
 			let result: _.Dictionary<CulturedList> = {};
-			_.each(AVAILABLE_LANGUAGES, (culture: string) => {
-				result[culture] = new CulturedList(culture);
-			});
+			_.each(AVAILABLE_LANGUAGES, (culture: string) => { result[culture] = new CulturedList(culture); });
 			return result;
 		}
 
 		public link(
 			scope: ILuidTranslationsListScope,
 			element: angular.IAugmentedJQuery,
-			attrs: angular.IAttributes & { mode: string },
+			attrs: angular.IAttributes & { mode: string, ngDisabled: boolean },
 			ctrls: [ng.INgModelController, LuidTranslationsListController]): void {
 
 			let ngModelCtrl = ctrls[0];

--- a/ts/translations-list/translations-list.directive.ts
+++ b/ts/translations-list/translations-list.directive.ts
@@ -1,4 +1,4 @@
-module lui.translationslist {
+module lui.translate {
 	"use strict";
 
 	class LuidTranslationsList implements angular.IDirective {
@@ -9,7 +9,7 @@ module lui.translationslist {
 		public require: string[] = ["ngModel", LuidTranslationsList.IID];
 		public scope = {
 			mode: "@", // Allowed values: "lucca",
-			disabled: "=ngDisabled", // enable editing
+			isDisabled: "=ngDisabled", // enable editing
 		};
 
 		public controller: string = LuidTranslationsListController.IID;
@@ -135,5 +135,5 @@ module lui.translationslist {
 			}, true);
 		}
 	}
-	angular.module("lui.translationslist").directive(LuidTranslationsList.IID, LuidTranslationsList.factory());
+	angular.module("lui.translate").directive(LuidTranslationsList.IID, LuidTranslationsList.factory());
 }

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -6,15 +6,15 @@
 	<content>
 		<ul class="lui unstyled field container">
 			<li class="lui input animated left fade in" ng-repeat="value in values[selectedCulture].values track by $index">
-				<input type="text" ng-model="values[selectedCulture].values[$index].value" ng-disabled="disabled" ng-paste="onPaste($event, $index)"
-					   placeholder="{{ values[currentCulture].values[$index].value || ( 'LUID_TRANSLATIONSLIST_INPUT_VALUE' | translate) }}"
+				<input type="text" ng-model="values[selectedCulture].values[$index].value" ng-disabled="isDisabled" ng-paste="onPaste($event, $index)"
+					   placeholder="{{ getPlaceholder(selectedCulture, $index) }}"
 					   luid-keydown mappings="addValueOnEnter" id="{{ $parent.selectedCulture + '_' + $index }}">
-				<!-- tabIndex = -1 ==> the element cannot be focused with tab -->
-				<button class="lui flat button icon cross close animated right fade in" ng-click="deleteValue($index)" ng-if="!disabled"
+				<!-- tabIndex = -1 : the element cannot be focused with tab -->
+				<button class="lui flat button icon cross close animated right fade in" ng-click="deleteValue($index)" ng-if="!isDisabled"
 						tabIndex="-1"></button>
 			</li>
 		</ul>
-		<footer ng-if="!disabled">
+		<footer ng-if="!isDisabled">
 			<button ng-click="addValue()" ng-hide="isAddValueDisabled()" class="lui button filled animated up fade in" translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
 		</footer>
 	</content>

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -6,14 +6,16 @@
 	<content>
 		<ul class="lui unstyled field container">
 			<li class="lui input animated left fade in" ng-repeat="value in values[selectedCulture].values track by $index">
-					<input type="text" ng-model="values[selectedCulture].values[$index].value"
-						placeholder="{{ values[currentCulture].values[$index].value || ( 'LUID_TRANSLATIONSLIST_INPUT_VALUE' | translate) }}">
-					<button class="lui flat button icon cross close" ng-click="deleteValue($index)" ng-if="!!canEdit"></button>
+				<input type="text" ng-model="values[selectedCulture].values[$index].value" ng-disabled="disabled" ng-paste="onPaste($event, $index)"
+					   placeholder="{{ values[currentCulture].values[$index].value || ( 'LUID_TRANSLATIONSLIST_INPUT_VALUE' | translate) }}"
+					   luid-keydown mappings="addValueOnEnter" id="{{ $parent.selectedCulture + '_' + $index }}">
+				<!-- tabIndex = -1 ==> the element cannot be focused with tab -->
+				<button class="lui flat button icon cross close animated right fade in" ng-click="deleteValue($index)" ng-if="!disabled"
+						tabIndex="-1"></button>
 			</li>
 		</ul>
-		<footer ng-if="!!canEdit">
-			<button ng-click="addValue()" ng-hide="canAddValue()" class="lui button filled animated up fade in" translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
+		<footer ng-if="!disabled">
+			<button ng-click="addValue()" ng-hide="isAddValueDisabled()" class="lui button filled animated up fade in" translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
 		</footer>
 	</content>
-
 </div>

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -1,0 +1,21 @@
+<div>
+	<nav class="lui dividing primary menu">
+		<a class="lui item" ng-repeat="culture in cultures" ng-class="{ 'active': culture === selectedCulture }"
+		   ng-click="selectCulture(culture)" ng-bind-html="culture | uppercase"></a>
+	</nav>
+	<content>
+		<ul class="lui unstyled">
+			<li class="lui field container" ng-repeat="value in values[selectedCulture].values track by $index">
+				<div class="lui input animated up fade in">
+					<input type="text" ng-model="values[selectedCulture].values[$index].value"
+						placeholder="{{ values[currentCulture].values[$index].value || ( 'LUID_TRANSLATIONSLIST_INPUT_VALUE' | translate) }}">
+					<button class="lui flat button small icon cross close" ng-click="deleteValue($index)"></button>
+				</div>
+			</li>
+		</ul>
+	</content>
+	<footer>
+		<button class="lui flat button" ng-click="addValue()" ng-disabled="canAddValue()"
+				translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
+	</footer>
+</div>

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -1,21 +1,19 @@
 <div>
-	<nav class="lui dividing primary menu">
+	<nav class="lui dividing justified primary menu">
 		<a class="lui item" ng-repeat="culture in cultures" ng-class="{ 'active': culture === selectedCulture }"
 		   ng-click="selectCulture(culture)" ng-bind-html="culture | uppercase"></a>
 	</nav>
 	<content>
-		<ul class="lui unstyled">
-			<li class="lui field container" ng-repeat="value in values[selectedCulture].values track by $index">
-				<div class="lui input animated up fade in">
+		<ul class="lui unstyled field container">
+			<li class="lui input animated left fade in" ng-repeat="value in values[selectedCulture].values track by $index">
 					<input type="text" ng-model="values[selectedCulture].values[$index].value"
 						placeholder="{{ values[currentCulture].values[$index].value || ( 'LUID_TRANSLATIONSLIST_INPUT_VALUE' | translate) }}">
-					<button class="lui flat button small icon cross close" ng-click="deleteValue($index)"></button>
-				</div>
+					<button class="lui flat button icon cross close" ng-click="deleteValue($index)" ng-if="!!canEdit"></button>
 			</li>
 		</ul>
+		<footer ng-if="!!canEdit">
+			<button ng-click="addValue()" ng-hide="canAddValue()" class="lui button filled animated up fade in" translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
+		</footer>
 	</content>
-	<footer>
-		<button class="lui flat button" ng-click="addValue()" ng-disabled="canAddValue()"
-				translate="LUID_TRANSLATIONSLIST_ADD_VALUE"></button>
-	</footer>
+
 </div>

--- a/ts/translations-list/translations-list.scope.ts
+++ b/ts/translations-list/translations-list.scope.ts
@@ -1,4 +1,4 @@
-module lui.translationslist {
+module lui.translate {
 	"use strict";
 
 	export interface ILuidTranslationsListScope extends ng.IScope {
@@ -11,19 +11,41 @@ module lui.translationslist {
 		/** ViewModel : Dictionary containing all the value which are currently displayed, ordered by culture */
 		values: _.Dictionary<CulturedList>;
 		/** Indicates if the user can modify the values */
-		disabled: boolean;
+		isDisabled: boolean;
 
+		/** Used to detect when the user presses the Enter key */
 		addValueOnEnter: { [key: number]: ($event: ng.IAngularEvent) => void };
 
-		/** Changes the active culture tab */
+		/**
+		 * Changes the active culture tab
+		 * @param {string} culture The culture which will become active
+		 */
 		selectCulture(culture: string): void;
+
 		/** Add a new value to each entry of the `values` dictionary */
 		addValue(): void;
-		/** Delete a value. The value is deleted in each entry of the `values` dictionary */
+
+		/**
+		 * Delete a value. The value is deleted in each entry of the `values` dictionary
+		 * @param {number} index The index of the value you want to delete
+		 */
 		deleteValue(index: number): void;
+
 		/** Indicates if the user can add a new value */
 		isAddValueDisabled(): boolean;
-		/** Called when the users paste something into an input */
+
+		/**
+		 * Called when the users paste something into an input
+		 * @param {ClipBoardEvent} event The copy/paste event
+		 * @param {number} index The index of the input where something was pasted
+		 */
 		onPaste(event: ClipboardEvent, index: number): void;
+
+		/**
+		 * Returns the placeholder for the input at the specified index, for the specified culture
+		 * @param {string} culture The culture for which you want a placeholder
+		 * @param {number} index The index of the input for which you want a placeholder
+		 */
+		getPlaceholder(culture: string, index: number): string;
 	}
 }

--- a/ts/translations-list/translations-list.scope.ts
+++ b/ts/translations-list/translations-list.scope.ts
@@ -8,8 +8,12 @@ module lui.translationslist {
 		currentCulture: string;
 		/** The selected culture */
 		selectedCulture: string;
-
+		/** ViewModel : Dictionary containing all the value which are currently displayed, ordered by culture */
 		values: _.Dictionary<CulturedList>;
+		/** Indicates if the user can modify the values */
+		disabled: boolean;
+
+		addValueOnEnter: { [key: number]: ($event: ng.IAngularEvent) => void };
 
 		/** Changes the active culture tab */
 		selectCulture(culture: string): void;
@@ -18,25 +22,8 @@ module lui.translationslist {
 		/** Delete a value. The value is deleted in each entry of the `values` dictionary */
 		deleteValue(index: number): void;
 		/** Indicates if the user can add a new value */
-		canAddValue(): boolean;
+		isAddValueDisabled(): boolean;
+		/** Called when the users paste something into an input */
+		onPaste(event: ClipboardEvent, index: number): void;
 	}
-
-	// export var luccaModelEx = [
-	// 	<LuccaTranslation>{
-	// 		id: 1,
-	// 		culturedLabels: [
-	// 			<LuccaCulturedLabel>{ id: 2, cultureCode: 1033, value: "stuff", translationId: 1 },
-	// 			<LuccaCulturedLabel>{ id: 3, cultureCode: 1033, value: "thing", translationId: 1 },
-	// 			<LuccaCulturedLabel>{ id: 4, cultureCode: 1033, value: "noice", translationId: 1 },
-	// 		]
-	// 	},
-	// 	<LuccaTranslation>{
-	// 		id: 1036,
-	// 		culturedLabels: [
-	// 			<LuccaCulturedLabel>{ id: 5, cultureCode: 1036, value: "truc", translationId: 2 },
-	// 			<LuccaCulturedLabel>{ id: 6, cultureCode: 1036, value: "bidule", translationId: 2 },
-	// 			<LuccaCulturedLabel>{ id: 7, cultureCode: 1036, value: "chouette", translationId: 2 },
-	// 		]
-	// 	},
-	// ];
 }

--- a/ts/translations-list/translations-list.scope.ts
+++ b/ts/translations-list/translations-list.scope.ts
@@ -1,0 +1,42 @@
+module lui.translationslist {
+	"use strict";
+
+	export interface ILuidTranslationsListScope extends ng.IScope {
+		/** List of all the available cultures */
+		cultures: string[];
+		/** The users preferred culture (displayed first in the tabs) */
+		currentCulture: string;
+		/** The selected culture */
+		selectedCulture: string;
+
+		values: _.Dictionary<CulturedList>;
+
+		/** Changes the active culture tab */
+		selectCulture(culture: string): void;
+		/** Add a new value to each entry of the `values` dictionary */
+		addValue(): void;
+		/** Delete a value. The value is deleted in each entry of the `values` dictionary */
+		deleteValue(index: number): void;
+		/** Indicates if the user can add a new value */
+		canAddValue(): boolean;
+	}
+
+	// export var luccaModelEx = [
+	// 	<LuccaTranslation>{
+	// 		id: 1,
+	// 		culturedLabels: [
+	// 			<LuccaCulturedLabel>{ id: 2, cultureCode: 1033, value: "stuff", translationId: 1 },
+	// 			<LuccaCulturedLabel>{ id: 3, cultureCode: 1033, value: "thing", translationId: 1 },
+	// 			<LuccaCulturedLabel>{ id: 4, cultureCode: 1033, value: "noice", translationId: 1 },
+	// 		]
+	// 	},
+	// 	<LuccaTranslation>{
+	// 		id: 1036,
+	// 		culturedLabels: [
+	// 			<LuccaCulturedLabel>{ id: 5, cultureCode: 1036, value: "truc", translationId: 2 },
+	// 			<LuccaCulturedLabel>{ id: 6, cultureCode: 1036, value: "bidule", translationId: 2 },
+	// 			<LuccaCulturedLabel>{ id: 7, cultureCode: 1036, value: "chouette", translationId: 2 },
+	// 		]
+	// 	},
+	// ];
+}


### PR DESCRIPTION
Added `luid-translations-list`, a directive to input multilingual lists.

![image](https://cloud.githubusercontent.com/assets/8553617/25438957/52813584-2a9b-11e7-90ad-21c1b90f2ffe.png)

Thanks @sanlucca for the style !