### PR TITLE
[FIX] Add ng-invalid handling for luid-translations and luid-translations-list

### DIFF
--- a/scss/core/elements/input/translations-list/_input.translations-list.compact.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.compact.scss
@@ -7,7 +7,10 @@
 
 			#{$prefix}.input#{$selector} luid-translations-list,
 			luid-translations-list#{$selector} {
-
+				&.ng-invalid.ng-dirty .lui.input > input,
+				&.ng-invalid.ng-touched .lui.input > input {
+					@extend %lui_input_invalid_input_compact;
+				}
 				// Adapt menu style for compact
 				#{$prefix}.menu.dividing:not(.vertical):not([class*="top dividing"]) {
 					border: 0;

--- a/scss/core/elements/input/translations-list/_input.translations-list.material.scss
+++ b/scss/core/elements/input/translations-list/_input.translations-list.material.scss
@@ -4,6 +4,10 @@
 			$selector: lui_input_get_style_selector("material");
 			#{$prefix}.input#{$selector} luid-translations-list,
 			luid-translations-list#{$selector} {
+				&.ng-invalid.ng-dirty .lui.input > input,
+				&.ng-invalid.ng-touched .lui.input > input {
+					@extend %lui_input_invalid_input_material;
+				}
 				> div {
 					box-shadow: 0 0 1px 0 rgba(0, 0, 0, .4);
 				}

--- a/scss/core/elements/input/translations/_input.translations.compact.scss
+++ b/scss/core/elements/input/translations/_input.translations.compact.scss
@@ -4,6 +4,10 @@
 			$selector: lui_input_get_style_selector("compact");
 			#{$prefix}.input#{$selector} luid-translations,
 			luid-translations#{$selector} {
+				&.ng-invalid.ng-dirty .lui.input > input,
+				&.ng-invalid.ng-touched .lui.input > input {
+					@extend %lui_input_invalid_input_compact;
+				}
 				.lui.input {
 					& > .unit {
 						@include flex-order(-1);

--- a/scss/core/elements/input/translations/_input.translations.material.scss
+++ b/scss/core/elements/input/translations/_input.translations.material.scss
@@ -4,6 +4,10 @@
 			$selector: lui_input_get_style_selector("material");
 			#{$prefix}.input#{$selector} luid-translations,
 			luid-translations#{$selector} {
+				&.ng-invalid.ng-dirty .lui.input > input,
+				&.ng-invalid.ng-touched .lui.input > input {
+					@extend %lui_input_invalid_input_material;
+				}
 				input {
 					@extend %lui_input_reset_material;
 


### PR DESCRIPTION
![ng-invalid on translations](https://cloud.githubusercontent.com/assets/26228000/25491298/dd3a20f8-2b6f-11e7-94a2-0fc9ebf000d1.PNG)
![ng-invalid on translations list](https://cloud.githubusercontent.com/assets/26228000/25491299/dd39fad8-2b6f-11e7-97cc-486f737d4e07.PNG)
