### PR TITLE
Fix.ngpaste.jquery

### DIFF
--- a/ts/iban/iban.controller.ts
+++ b/ts/iban/iban.controller.ts
@@ -56,10 +56,11 @@ module lui.iban {
 				this.setViewValue(this.$scope.countryCode.toUpperCase() + this.$scope.controlKey.toUpperCase() + this.$scope.bban.toUpperCase());
 			};
 
-			this.$scope.pasteIban = (event: ClipboardEvent): void => {
-				this.setViewValue(event.clipboardData.getData("text/plain").replace(/ /g, ""));
+			this.$scope.pasteIban = (event: ClipboardEvent | JQueryEventObject): void => {
+				let originalEvent = event instanceof ClipboardEvent ? <ClipboardEvent>event : (<ClipboardEvent>(<JQueryEventObject>event).originalEvent);
+				this.setViewValue(originalEvent.clipboardData.getData("text/plain").replace(/ /g, ""));
 				this.ngModelCtrl.$render();
-				(<HTMLInputElement>event.target).blur();
+				(<HTMLInputElement>originalEvent.target).blur();
 			};
 
 			this.$scope.selectInput = (event: JQueryEventObject): void => {

--- a/ts/iban/iban.scope.ts
+++ b/ts/iban/iban.scope.ts
@@ -10,7 +10,7 @@ module lui.iban {
 		controlKeyMappings: { [key: number]: ($event: ng.IAngularEvent) => void; };
 
 		updateValue(): void;
-		pasteIban(event: ClipboardEvent): void;
+		pasteIban(event: ClipboardEvent | JQueryEventObject): void;
 		selectInput(event: JQueryEventObject): void;
 		setTouched(): void;
 	}

--- a/ts/translations-list/translations-list.controller.ts
+++ b/ts/translations-list/translations-list.controller.ts
@@ -57,11 +57,13 @@ module lui.translate {
 				});
 			};
 
-			$scope.onPaste = (event: ClipboardEvent, index: number): void => {
+			$scope.onPaste = (event: ClipboardEvent | JQueryEventObject, index: number): void => {
 				// Don't do anything if the directive is disabled
 				if ($scope.isDisabled) { return; }
 
-				let values = _.reject(event.clipboardData.getData("text/plain").split("\r\n"), (value: string) => value === "");
+				let originalEvent: ClipboardEvent = event instanceof ClipboardEvent ? <ClipboardEvent>event : (<ClipboardEvent>(<JQueryEventObject>event).originalEvent);
+				let values = _.reject(originalEvent.clipboardData.getData("text/plain").split("\r\n"), (value: string) => value === "");
+
 				if (values.length <= 1) { return; }
 
 				// If the first item in the selectedCulture isn't empty, simply paste the first value inside it
@@ -81,7 +83,7 @@ module lui.translate {
 					}
 				});
 
-				(<HTMLInputElement>event.target).blur();
+				(<HTMLInputElement>originalEvent.target).blur();
 			};
 
 			$scope.addValueOnEnter = {

--- a/ts/translations-list/translations-list.controller.ts
+++ b/ts/translations-list/translations-list.controller.ts
@@ -92,7 +92,7 @@ module lui.translate {
 			$scope.addValueOnEnter = {
 				"13": ($event: JQueryEventObject): void => {
 					// The index is stored in the target's id (not very pretty ikr)
-					let index = Number($event.target.id.split("_")[1]);
+					let index = Number($event.target.id.split("_")[2]);
 					if (index === $scope.values[$scope.selectedCulture].values.length - 1) {
 						if (!$scope.isAddValueDisabled()) {
 							// Add a value
@@ -100,12 +100,12 @@ module lui.translate {
 							$scope.addValue();
 							$scope.$apply();
 							$timeout(() => {
-								document.getElementById($scope.selectedCulture + "_" + index).focus();
+								document.getElementById($scope.getUniqueId($scope.selectedCulture, index)).focus();
 							});
 						}
 					} else {
 						index++;
-						document.getElementById($scope.selectedCulture + "_" + index).focus();
+						document.getElementById($scope.getUniqueId($scope.selectedCulture, index)).focus();
 						$scope.$apply();
 					}
 
@@ -121,6 +121,10 @@ module lui.translate {
 
 				let currentCultureValue = $scope.values[$scope.currentCulture].values[index].value;
 				return $scope.isDisabled ? "" : (!!currentCultureValue ? currentCultureValue : $translate.instant("LUID_TRANSLATIONSLIST_INPUT_VALUE"));
+			};
+
+			$scope.getUniqueId = (culture: string, index: number): string => {
+				return `${culture}_${$scope.uniqueId}_${index}`;
 			};
 		}
 	}

--- a/ts/translations-list/translations-list.controller.ts
+++ b/ts/translations-list/translations-list.controller.ts
@@ -48,6 +48,7 @@ module lui.translate {
 						$scope.values[culture].values.push(<ICulturedValue>{ value: "" });
 					});
 				}
+				$scope.onInputValueChanged();
 			};
 
 			$scope.isAddValueDisabled = (): boolean => {
@@ -83,11 +84,13 @@ module lui.translate {
 					}
 				});
 
+				$scope.onInputValueChanged();
+
 				(<HTMLInputElement>originalEvent.target).blur();
 			};
 
 			$scope.addValueOnEnter = {
-				"13": ($event: any): void => {
+				"13": ($event: JQueryEventObject): void => {
 					// The index is stored in the target's id (not very pretty ikr)
 					let index = Number($event.target.id.split("_")[1]);
 					if (index === $scope.values[$scope.selectedCulture].values.length - 1) {
@@ -105,6 +108,8 @@ module lui.translate {
 						document.getElementById($scope.selectedCulture + "_" + index).focus();
 						$scope.$apply();
 					}
+
+					$event.preventDefault();
 				}
 			};
 

--- a/ts/translations-list/translations-list.directive.ts
+++ b/ts/translations-list/translations-list.directive.ts
@@ -130,6 +130,9 @@ module lui.translate {
 			let mode = attrs.mode;
 			if (!mode) { mode = "lucca"; }
 
+			// Unique identifier
+			scope.uniqueId = (Math.floor(Math.random() * 9000) + 1).toString();
+
 			scope.onInputValueChanged = (): void => {
 				ngModelCtrl.$setViewValue(LuidTranslationsList.toModel(scope.values, mode));
 			};

--- a/ts/translations-list/translations-list.directive.ts
+++ b/ts/translations-list/translations-list.directive.ts
@@ -82,7 +82,7 @@ module lui.translate {
 		private static parseLucca(value: ILuccaTranslation[]): _.Dictionary<CulturedList> {
 			let result: _.Dictionary<CulturedList> = LuidTranslationsList.getEmptyCulturedLists();
 
-			if (!value.length) {
+			if (value === undefined || value === null || !value.length) {
 				_.each(AVAILABLE_LANGUAGES, (culture: string) => {
 					result[culture].values.push(<ICulturedValue>{ value: "" });
 				});

--- a/ts/translations-list/translations-list.directive.ts
+++ b/ts/translations-list/translations-list.directive.ts
@@ -123,16 +123,16 @@ module lui.translate {
 			let mode = attrs.mode;
 			if (!mode) { mode = "lucca"; }
 
+			scope.onInputValueChanged = (): void => {
+				ngModelCtrl.$setViewValue(LuidTranslationsList.toModel(scope.values, mode));
+			};
+
 			ngModelCtrl.$render = (): void => {
 				let viewModel = LuidTranslationsList.parse(ngModelCtrl.$viewValue, mode);
 				if (!!viewModel) {
 					scope.values = viewModel;
 				}
 			};
-
-			scope.$watch("values", (): void => {
-				ngModelCtrl.$setViewValue(LuidTranslationsList.toModel(scope.values, mode));
-			}, true);
 		}
 	}
 	angular.module("lui.translate").directive(LuidTranslationsList.IID, LuidTranslationsList.factory());

--- a/ts/translations-list/translations-list.directive.ts
+++ b/ts/translations-list/translations-list.directive.ts
@@ -82,6 +82,13 @@ module lui.translate {
 		private static parseLucca(value: ILuccaTranslation[]): _.Dictionary<CulturedList> {
 			let result: _.Dictionary<CulturedList> = LuidTranslationsList.getEmptyCulturedLists();
 
+			if (!value.length) {
+				_.each(AVAILABLE_LANGUAGES, (culture: string) => {
+					result[culture].values.push(<ICulturedValue>{ value: "" });
+				});
+				return result;
+			}
+
 			_.each(value, (translation: ILuccaTranslation) => {
 				_.each(translation.culturedLabels, (label: ILuccaCulturedLabel) => {
 					let language = CODES_TO_LANGUAGES[label.cultureCode];

--- a/ts/translations-list/translations-list.directive.ts
+++ b/ts/translations-list/translations-list.directive.ts
@@ -135,6 +135,7 @@ module lui.translate {
 
 			scope.onInputValueChanged = (): void => {
 				ngModelCtrl.$setViewValue(LuidTranslationsList.toModel(scope.values, mode));
+				ngModelCtrl.$setTouched();
 			};
 
 			ngModelCtrl.$render = (): void => {

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -8,7 +8,7 @@
 			<li class="lui input animated left fade in" ng-repeat="value in values[selectedCulture].values track by $index">
 				<input type="text" ng-model="values[selectedCulture].values[$index].value" ng-disabled="isDisabled" ng-paste="onPaste($event, $index)"
 					   placeholder="{{ getPlaceholder(selectedCulture, $index) }}" ng-change="onInputValueChanged()"
-					   luid-keydown mappings="addValueOnEnter" id="{{ $parent.selectedCulture + '_' + $index }}">
+					   luid-keydown mappings="addValueOnEnter" id="{{ getUniqueId($parent.selectedCulture, $index) }}">
 				<!-- tabIndex = -1 : the element cannot be focused with tab -->
 				<button class="lui flat button icon cross close animated right fade in" ng-click="deleteValue($index)" ng-if="!isDisabled"
 						tabIndex="-1"></button>

--- a/ts/translations-list/translations-list.html
+++ b/ts/translations-list/translations-list.html
@@ -7,7 +7,7 @@
 		<ul class="lui unstyled field container">
 			<li class="lui input animated left fade in" ng-repeat="value in values[selectedCulture].values track by $index">
 				<input type="text" ng-model="values[selectedCulture].values[$index].value" ng-disabled="isDisabled" ng-paste="onPaste($event, $index)"
-					   placeholder="{{ getPlaceholder(selectedCulture, $index) }}"
+					   placeholder="{{ getPlaceholder(selectedCulture, $index) }}" ng-change="onInputValueChanged()"
 					   luid-keydown mappings="addValueOnEnter" id="{{ $parent.selectedCulture + '_' + $index }}">
 				<!-- tabIndex = -1 : the element cannot be focused with tab -->
 				<button class="lui flat button icon cross close animated right fade in" ng-click="deleteValue($index)" ng-if="!isDisabled"

--- a/ts/translations-list/translations-list.scope.ts
+++ b/ts/translations-list/translations-list.scope.ts
@@ -14,7 +14,7 @@ module lui.translate {
 		isDisabled: boolean;
 
 		/** Used to detect when the user presses the Enter key */
-		addValueOnEnter: { [key: number]: ($event: ng.IAngularEvent) => void };
+		addValueOnEnter: { [key: number]: ($event: JQueryEventObject) => void };
 
 		/**
 		 * Changes the active culture tab
@@ -47,5 +47,8 @@ module lui.translate {
 		 * @param {number} index The index of the input for which you want a placeholder
 		 */
 		getPlaceholder(culture: string, index: number): string;
+
+		/** Called when the users changes the text of an input. This method is set inside the directive file and calls ngModelCtrl.$setViewValue() */
+		onInputValueChanged(): void;
 	}
 }

--- a/ts/translations-list/translations-list.scope.ts
+++ b/ts/translations-list/translations-list.scope.ts
@@ -39,7 +39,7 @@ module lui.translate {
 		 * @param {ClipBoardEvent} event The copy/paste event
 		 * @param {number} index The index of the input where something was pasted
 		 */
-		onPaste(event: ClipboardEvent, index: number): void;
+		onPaste(event: ClipboardEvent | JQueryEventObject, index: number): void;
 
 		/**
 		 * Returns the placeholder for the input at the specified index, for the specified culture

--- a/ts/translations-list/translations-list.scope.ts
+++ b/ts/translations-list/translations-list.scope.ts
@@ -16,6 +16,9 @@ module lui.translate {
 		/** Used to detect when the user presses the Enter key */
 		addValueOnEnter: { [key: number]: ($event: JQueryEventObject) => void };
 
+		/** Identifier used to add unique Ids to the inputs of the directive */
+		uniqueId: string;
+
 		/**
 		 * Changes the active culture tab
 		 * @param {string} culture The culture which will become active
@@ -50,5 +53,8 @@ module lui.translate {
 
 		/** Called when the users changes the text of an input. This method is set inside the directive file and calls ngModelCtrl.$setViewValue() */
 		onInputValueChanged(): void;
+
+		/** Generates a unique identifier for the inputs displayed in the directive */
+		getUniqueId(culture: string, index: number): string;
 	}
 }


### PR DESCRIPTION
Fixed issues in `luid-iban` and `luid-translations-list` which happened on projects which uses JQuery and load it before Angular. JQuery overlays all the JS events, which makes `ng-paste` directive unusable. 

fixes #441 

Also, fixed some issues with `luid-translations-list`:
- added unique added to each input displayed in the directive, to be able to display multiple times on the same page
- fixed an issue where the directive didn't work when the ng-model was defined but empty