### PR TITLE
[FIX] luid-image-picker loading states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## in dev
 ### Bug fixes
+- `luid-image-picker`: fixed issue with loading states not showing
 
 ## 3.1.10 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.10)
 ### Bug fixes

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.common.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.common.scss
@@ -30,6 +30,11 @@
 					transition: map-gets($vars, overlay, transition);
 				}
 
+				.upload-overlay {
+					height: 0;
+					background-color: map-gets($vars, overlay, bg-color);
+				}
+
 				.input-overlay {
 					font-size: lui_rem(1);
 					text-align: center;

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.common.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.common.scss
@@ -56,9 +56,10 @@
 					text-indent: -100%;
 				}
 
-				.loader {
+				.lui.loader.inverted {
 					position: absolute;
-					top: 50%; left: 50%;
+					top: 50%;
+					left: 50%;
 					transform: translate(-50%, -50%);
 				}
 			}
@@ -69,9 +70,9 @@
 				}
 			}
 
-			&.uploading {
-				.input-overlay { display: none; }
-				.upload-overlay { height: 100%; }
+			.lui.image-picker.uploading .luid-image-picker-picture {
+				> .input-overlay { display: none; }
+				> .upload-overlay { height: 100%; }
 			}
 			&.round {
 				.luid-image-picker-picture {

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.compact.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.compact.scss
@@ -11,11 +11,6 @@
 				max-height: 1em + 2 * luiTheme(element, field, input, vertical-padding);
 				line-height: 1em + 2 * luiTheme(element, field, input, vertical-padding);
 
-				.upload-overlay {
-					height: 0;
-					background-color: black;
-				}
-
 				.input-overlay {
 					height: 1em + 2 * luiTheme(element, field, input, vertical-padding);
 				}

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.compact.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.compact.scss
@@ -13,6 +13,7 @@
 
 				.upload-overlay {
 					height: 0;
+					background-color: black;
 				}
 
 				.input-overlay {

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
@@ -13,13 +13,10 @@
 					background-size: map-gets($vars, background-size);
 				}
 
-				.input-overlay,
-				.upload-overlay {
+				.input-overlay {
 					height: 0;
 					background-color: map-gets($vars, overlay, bg-color);
-				}
 
-				.input-overlay {
 					> span {
 						padding: map-gets($vars, overlay, padding);
 					}

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
@@ -25,6 +25,10 @@
 					}
 				}
 
+				.upload-overlay .loader{
+					font-size: 3em;
+				}
+
 				&:hover {
 					.input-overlay {
 						height: map-gets($vars, overlay, height);

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
@@ -26,7 +26,7 @@
 				}
 
 				.upload-overlay .loader{
-					font-size: 3em;
+					font-size: map-gets($vars, material, loader-size);
 				}
 
 				&:hover {

--- a/scss/themes/default/core/elements/_field.defaults.scss
+++ b/scss/themes/default/core/elements/_field.defaults.scss
@@ -123,7 +123,9 @@ $field: (
 			bg-color: 			luiPalette(light, color),
 			height: 			40em,
 		),
-
+		material: (
+			loader-size: 			3em,
+		)
 	),
 
 	momentpicker: (

--- a/ts/image-picker/image-picker.html
+++ b/ts/image-picker/image-picker.html
@@ -6,6 +6,6 @@
 		<i ng-if="deleteEnabled" class="empty" ng-click="onDelete()"></i>
 	</div>
 	<div class="upload-overlay">
-		<div class="lui inverted x-large loader"></div>
+		<div class="lui inverted loader"></div>
 	</div>
 </div>


### PR DESCRIPTION
Loading states were not showing due to wrong class indentation.
Material :
![msil9jjvy5](https://cloud.githubusercontent.com/assets/26228000/26623073/c99480ec-45ec-11e7-977a-90eef19f9411.gif)

Compact:
![yqvfbrbxis](https://cloud.githubusercontent.com/assets/26228000/26623076/cdba0eb2-45ec-11e7-9705-8068706bd51e.gif)
