### PR TITLE
[fix] RCT-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## in dev
 ### Bug fixes
 - `luid-table-grid` fix issue when datas attribut contains numeric values.
+- `luid-user-picker` fixed issue where former employees were still displayed even though `show-former-employees` was set to false
 
 ## 3.1.12 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.12)
 ### Changes (non-breaking)

--- a/ts/user-picker/user-picker.controller.ts
+++ b/ts/user-picker/user-picker.controller.ts
@@ -99,7 +99,7 @@ module lui.userpicker {
 			});
 
 			this.$scope.$watch("showFormerEmployees", (newValue: boolean, oldValue: boolean) => {
-				if (!!this.$scope.showFormerEmployees && newValue !== oldValue) {
+				if (this.$scope.showFormerEmployees !== undefined && newValue !== oldValue) {
 					this.resetUsers();
 					this.refresh();
 				}


### PR DESCRIPTION
`luid-user-picker`: fixed issue where former employees were still displayed even though `show-former-employees` was set to false
