### PR TITLE
[FIX] Fix daterange picker compact style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `luid-daterange-picker`: fixed an issue with focus styling
 - `luid-table-grid` fix issue when datas attribut contains numeric values.
 - `luid-user-picker` fixed issue where former employees were still displayed even though `show-former-employees` was set to false
+- `luid-daterange-picker` - fixed style where the two inputs where larger than the main input
 
 ### Enhancements
 - `luid-user-picker` does not close dropdown when `include-former-employees` attribute changes

--- a/scss/core/elements/input/datepicker/_input.datepicker.compact.scss
+++ b/scss/core/elements/input/datepicker/_input.datepicker.compact.scss
@@ -1,4 +1,4 @@
-@if luiTheme(element, field, momentpicker, enabled) {
+@if luiTheme(element, field, datepicker, enabled) {
 	@at-root #{$namespace} {
 		@if lui_input_style_enabled("compact") {
 			$selector: lui_input_get_style_selector("compact");
@@ -19,10 +19,14 @@
 				}
 			}
 
-      #{$prefix}.input#{$selector} luid-daterange-picker .inputs,
+			#{$prefix}.input#{$selector} luid-daterange-picker .inputs,
 			luid-daterange-picker#{$selector} .inputs {
+				> input {
+					width: calc(50% - 5px) !important;
+				}
 				.icon {
 					transform: translate(10%, -50%);
+					left: calc(50% - 5px);
 				}
 
 				> input:last-of-type {

--- a/scss/core/elements/input/datepicker/_input.datepicker.material.scss
+++ b/scss/core/elements/input/datepicker/_input.datepicker.material.scss
@@ -1,4 +1,4 @@
-@if luiTheme(element, field, momentpicker, enabled) {
+@if luiTheme(element, field, datepicker, enabled) {
 	@at-root #{$namespace} {
 		@if lui_input_style_enabled("material") {
 			$selector: lui_input_get_style_selector("material");


### PR DESCRIPTION
Fixed luid-daterange-picker compact style where inputs were taking more space than other compact inputs