### PR TITLE
Datepicker Keyboard interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## in dev
+### Changes (non-breaking)
+- `luid-date-picker` selects input text when editing a non-empty input
+- `luid-date-picker` can be closed with the "ENTER" key
 ### Bug fixes
 - `luid-table-grid` fix issue when datas attribut contains numeric values.
 

--- a/ts/date-picker/datepicker-popup.html
+++ b/ts/date-picker/datepicker-popup.html
@@ -9,7 +9,7 @@
 			   ng-model="displayStr"
 			   ng-change="onDisplayStrChanged($event)"
 			   ng-focus="openPopover($event)"
-			   luid-keydown mappings="closePopoverOnTab"
+			   luid-keydown mappings="closePopoverOnKeyPress"
 			   placeholder="{{placeholder}}">
 		<i class="empty" ng-click="clear($event)"></i>
 </div>

--- a/ts/date-picker/datepicker.directive.ts
+++ b/ts/date-picker/datepicker.directive.ts
@@ -104,7 +104,7 @@ module lui.datepicker {
 				this.openPopover($event);
 			};
 
-			$scope.closePopoverOnTab = { 9: ($event: ng.IAngularEvent): void => { this.closePopover(); this.$scope.$apply(); } };
+			$scope.closePopoverOnTab = { [9,13]: ($event: ng.IAngularEvent): void => { this.closePopover(); this.$scope.$apply(); } };
 
 			$scope.$watch("min", (): void => {
 				// revalidate
@@ -257,7 +257,8 @@ module lui.datepicker {
 				this.popoverController.open($event);
 			}
 			if (!this.$scope.disableKeyboardInput) {
-				this.$scope.displayStr = "";
+				let input = this.element.children().children()[0] as HTMLInputElement;
+				input.select();
 			}
 		}
 

--- a/ts/date-picker/datepicker.directive.ts
+++ b/ts/date-picker/datepicker.directive.ts
@@ -73,7 +73,7 @@ module lui.datepicker {
 		displayStr: string;
 		displayFormat: string;
 
-		closePopoverOnTab: { [key: number]: ($event: ng.IAngularEvent) => void };
+		closePopoverOnKeyPress: { [key: number]: ($event: ng.IAngularEvent) => void };
 
 		disableKeyboardInput: boolean;
 
@@ -104,7 +104,10 @@ module lui.datepicker {
 				this.openPopover($event);
 			};
 
-			$scope.closePopoverOnTab = { [9,13]: ($event: ng.IAngularEvent): void => { this.closePopover(); this.$scope.$apply(); } };
+			$scope.closePopoverOnKeyPress = {
+				9 : ($event: ng.IAngularEvent): void => { this.closePopover(); this.$scope.$apply(); },
+				13 :  ($event: ng.IAngularEvent): void => { this.closePopover(); this.$scope.$apply(); this.element.find('input')[0].blur(); }
+			};
 
 			$scope.$watch("min", (): void => {
 				// revalidate


### PR DESCRIPTION
Datepicker input text is selected when keyboard is enabled and the input is already filled.
luid-datepicker can now be closed with "ENTER"
![datepicker](https://user-images.githubusercontent.com/26228000/27474817-63edbe10-5803-11e7-91d2-f23e5e431b0b.gif)
