### PR TITLE
Compact label sizes & fitting style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - `luid-daterange-picker`: fixed an issue with focus styling
 - `luid-table-grid` fix issue when datas attribut contains numeric values.
 - `luid-user-picker` fixed issue where former employees were still displayed even though `show-former-employees` was set to false
+- `compact` fixed issues where `fitting` was not taking label size in account.
 
 ### Enhancements
 - `luid-user-picker` does not close dropdown when `include-former-employees` attribute changes
+- `compact` you can change label width using classes `label-{sizename}`
 
 ## 3.1.12 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.12)
 ### Changes (non-breaking)

--- a/demo/sass/inputs/inputs.html
+++ b/demo/sass/inputs/inputs.html
@@ -668,3 +668,24 @@
 				<pre hljs language="html"><luid-translations ng-model="ctranslations" class="lui compact"></luid-translations></pre>
 			</div>
 		</div>
+
+
+<div class="lui dashed divider">
+	<h4 class="lui underline">Fitting input</h4>
+</div>
+<div class="flex-container flex-row-container flex-two-columns">
+	<div class="flex-column">
+			<h5>Material</h5>
+			<div class="lui input material fitting">
+				<input type="text" name="fitting_material">
+				<label for="fitting_material">Fitting input</label>
+			</div>
+		</div>
+		<div class="flex-column">
+			<h5>Compact</h5>
+			<div class="lui input compact fitting">
+				<input type="text" name="fitting_compact">
+				<label for="fitting_compact">Fitting input</label>
+			</div>
+		</div>
+	</div>

--- a/scss/core/elements/_field.scss
+++ b/scss/core/elements/_field.scss
@@ -132,7 +132,7 @@
 		// Sizing
 		@each $sizeName, $sizeEms in map-gets($vars, lengths) {
 			#{$prefix}.field.#{$sizeName} > .input > *[ng-model]:not([type="checkbox"]):not([type="radio"]):not([size]),
-			#{$prefix}.field.#{$sizeName} > .input:not(.radio):not(.checkbox):not(.switch) > label {
+			#{$prefix}.field.#{$sizeName} > .input:not(.radio):not(.checkbox):not(.switch):not(.compact) > label {
 				min-width: 0;
 				width: $sizeEms;
 			}
@@ -142,13 +142,13 @@
 		// =====================================================================
 		#{$prefix}.fitting.field,
 		#{$prefix}.fitting.field > .input,
-		#{$prefix}.fitting.field > .input > label,
+		#{$prefix}.fitting.field > .input:not(.compact) > label,
 		#{$prefix}.fitting.input,
-		#{$prefix}.fitting.input > label {
+		#{$prefix}.fitting.input:not(.compact) > label {
 			width: 100% !important;
 		}
-		#{$prefix}.fitting.field > .input,
-		#{$prefix}.fitting.input {
+		#{$prefix}.fitting.field > .input:not(.compact),
+		#{$prefix}.fitting.input:not(.compact) {
 			& > *[ng-model]:not([type="checkbox"]):not([type="radio"]), & > input:not([type="checkbox"]):not([type="radio"]) {
 				width: 100%;
 			}

--- a/scss/core/elements/_field.scss
+++ b/scss/core/elements/_field.scss
@@ -149,7 +149,7 @@
 		}
 		#{$prefix}.fitting.field > .input,
 		#{$prefix}.fitting.input {
-			& > *[ng-model]:not([type="checkbox"]):not([type="radio"]) {
+			& > *[ng-model]:not([type="checkbox"]):not([type="radio"]), & > input:not([type="checkbox"]):not([type="radio"]) {
 				width: 100%;
 			}
 		}

--- a/scss/core/elements/input/_input.compact.scss
+++ b/scss/core/elements/input/_input.compact.scss
@@ -53,7 +53,7 @@
 @if (luiTheme(element, field, enabled)) {
 	@if lui_input_style_enabled("compact") {
 		$selector: lui_input_get_style_selector("compact");
-
+		$vars: luiTheme(element, field, input, compact);
 		#{$prefix}.input#{$selector} {
 			> input:not([type="checkbox"]):not([type="radio"]),
 			> textarea,
@@ -99,7 +99,6 @@
 				margin-right: 0;
 			}
 		}
-
 		// Sizing
 		@each $sizeName, $sizeEms in luiTheme(element, field, lengths) {
 			#{$prefix}.input.#{$sizeName}#{$selector} > *[ng-model]:not([type="checkbox"]):not([type="radio"]):not([size]) {
@@ -108,12 +107,36 @@
 			}
 		}
 
+		#{$prefix}.fitting.field > .input#{$selector},
+		#{$prefix}.fitting.field#{$selector} > .input,
+		#{$prefix}.fitting.input#{$selector} {
+			& > *[ng-model]:not([type="checkbox"]):not([type="radio"]), & > input:not([type="checkbox"]):not([type="radio"]) {
+				width: calc(100% - #{map-gets($vars, label-lengths, medium)} - #{map-gets($vars, label-right-padding)});
+			}
+		}
+
 		#{$prefix}.input#{$selector}:not(.radio):not(.checkbox):not(.switch) > label {
-			width: 7em !important;
+			width: map-gets($vars, label-lengths, medium);
 			white-space: inherit;
 			word-break: break-word;
-			margin-right: 1em;
+			margin-right: map-gets($vars, label-right-padding);
 		}
+
+
+		@each $sizeName, $sizeEms in map-gets($vars, label-lengths) {
+			#{$prefix}.input#{$selector}.label-#{$sizeName}:not(.radio):not(.checkbox):not(.switch) > label {
+				width: $sizeEms;
+			}
+			#{$prefix}.fitting.field > .input#{$selector},
+			#{$prefix}.fitting.field#{$selector} > .input.label-#{$sizeName},
+			#{$prefix}.fitting.input#{$selector}.label-#{$sizeName} {
+				& > *[ng-model]:not([type="checkbox"]):not([type="radio"]), & > input:not([type="checkbox"]):not([type="radio"]) {
+					width: calc(100% - #{$sizeEms} - #{map-gets($vars, label-right-padding)});
+				}
+			}
+		}
+
+
 	}
 }
 

--- a/scss/themes/default/core/elements/_field.defaults.scss
+++ b/scss/themes/default/core/elements/_field.defaults.scss
@@ -58,6 +58,16 @@ $field: (
 			focus: (
 				background-color: 	#fafafa,
 				border-color: luiPalette(grey, color)
+			),
+
+			label-right-padding: 1em,
+
+			label-lengths: (
+				x-short: 3em,
+				short: 5em,
+				medium: 7em,
+				large: 9em,
+				x-large: 11em
 			)
 		)
 	),


### PR DESCRIPTION
Add better handling of fitting input for compact style.
Add classes `label-{size}` to be able to change label width in compact mode.