### PR TITLE
luid-image-picker popover and edit icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 ## in dev
+### Changes (non-breaking)
+- `luid-image-picker`: displays a popover when a file as been uploaded and deleteEnabled is true
+- `luid-image-picker`: material design now shows an edit icon by default. It can be disabled by setting the attribute `hide-edit-hint` to true
 ### Bug fixes
 - `luid-daterange-picker`: fixed an issue with focus styling
 - `luid-table-grid` fix issue when datas attribut contains numeric values.

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.common.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.common.scss
@@ -7,7 +7,8 @@
 			display: inline-block;
 			width: 100%;
 			height: 100%;
-
+			cursor: pointer;
+			
 			> div { height: 100%; }
 
 			.luid-image-picker-picture {
@@ -70,7 +71,7 @@
 			}
 			&[disabled="disabled"] {
 				color: red;
-				.input-overlay {
+				.input-overlay, input {
 					display: none !important;
 				}
 			}
@@ -82,6 +83,32 @@
 			&.round {
 				.luid-image-picker-picture {
 					border-radius: 50%;
+				}
+			}
+		}
+
+		.luid-image-picker-popup.lui.popover {
+			height: auto;
+			.popover-inner {
+				padding: 0;
+				margin-top: 0 !important;
+				background: white;
+				.image-picker-menu {
+					margin: 0;
+					padding: 0;
+
+					li {
+						padding: .5em 1em;
+						cursor: pointer;
+						transition: all .15s ease-out;
+						& + li {
+							border-top: 1px solid grey;
+						}
+
+						&:hover {
+							background: darken(white, 10%);
+						}
+					}
 				}
 			}
 		}

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.common.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.common.scss
@@ -8,7 +8,7 @@
 			width: 100%;
 			height: 100%;
 			cursor: pointer;
-			
+
 			> div { height: 100%; }
 
 			.luid-image-picker-picture {
@@ -92,10 +92,11 @@
 			.popover-inner {
 				padding: 0;
 				margin-top: 0 !important;
-				background: white;
+				background: map-gets($vars, popover, bg-color);
+				color: luiTheme(element, typography, body, color);
 				.image-picker-menu {
-					margin: 0;
-					padding: 0;
+					@extend %lui_unstyled_list;
+					@include lui_raised(2);
 
 					li {
 						padding: .5em 1em;
@@ -106,7 +107,7 @@
 						}
 
 						&:hover {
-							background: darken(white, 10%);
+							background: map-gets($vars, popover, hover-color);
 						}
 					}
 				}

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.compact.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.compact.scss
@@ -6,7 +6,7 @@
 			$vars: luiTheme(element, field, image-picker);
 
 			#{$prefix}.input#{$selector} luid-image-picker, luid-image-picker#{$selector} {
-
+				position: relative;
 				height: 1em + 2 * luiTheme(element, field, input, vertical-padding);
 				max-height: 1em + 2 * luiTheme(element, field, input, vertical-padding);
 				line-height: 1em + 2 * luiTheme(element, field, input, vertical-padding);
@@ -16,9 +16,18 @@
 				}
 
 				.input-overlay {
-					> span {
+					.overlay-content {
 						color: #A6A6A6;
+						> i {
+							display: none;
+						}
 					}
+				}
+
+				.luid-image-picker-popup.lui.popover {
+					top: 100% !important;
+					left: 0 !important;
+					line-height: 1.4em;
 				}
 
 				&:hover {
@@ -30,13 +39,17 @@
 				}
 
 				.luid-image-picker-picture {
-					padding-left: 1em + 2 * luiTheme(element, field, input, vertical-padding);
 					background-position: 0 0;
 					background-repeat: no-repeat;
 					background-size: contain;
 					background-color: luiTheme(element, field, input, compact, background-color);
 					border: 1px dashed #DAE0E4;
 					border-radius: luiTheme(element, field, input, compact, border-radius);
+
+					.input-overlay,
+					.output-overlay {
+						padding-left: 1em;
+					}
 				}
 			}
 		}

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
@@ -32,6 +32,9 @@
 					opacity: .4;
 					transition: all .15s ease-out;
 					transform-origin: bottom right;
+					&.hide-editable {
+						opacity: 0;
+					}
 
 					> .overlay-content {
 						position: absolute;
@@ -60,7 +63,7 @@
 				}
 
 				&:hover {
-					.input-overlay {
+					.input-overlay, .input-overlay.hide-editable {
 						width: 100%;
 						height: 100%;
 						bottom: 0;

--- a/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
+++ b/scss/core/elements/input/imagepicker/_input.imagepicker.material.scss
@@ -7,19 +7,52 @@
 
 			#{$prefix}.input#{$selector} luid-image-picker,
 			luid-image-picker#{$selector} {
+				position: relative;
 				.luid-image-picker-picture {
 					background-position: map-gets($vars, background-position);
 					background-repeat: map-gets($vars, background-repeat);
 					background-size: map-gets($vars, background-size);
+					overflow: hidden;
+				}
+
+				.luid-image-picker-popup.lui.popover {
+					top: 50% !important;
+					left: 50% !important;
+					transform: translate(-50%, -40%) scale(1) !important;
 				}
 
 				.input-overlay {
-					height: 0;
 					background-color: map-gets($vars, overlay, bg-color);
+					position: absolute;
+					bottom: 0;
+					right: 0;
+					left: auto;
+					width: 2em;
+					height: 2em;
+					opacity: .4;
+					transition: all .15s ease-out;
+					transform-origin: bottom right;
 
-					> span {
-						padding: map-gets($vars, overlay, padding);
+					> .overlay-content {
+						position: absolute;
+						top: 0;
+						left: 0;
+						width: 100%;
+						transform: translate(0, 0);
+						transition: all .15s ease-out;
+						> i {
+							line-height: 2em;
+							margin-top: 0;
+							display: block;
+						}
+						> span {
+							text-align: center;
+							display: none;
+							padding: map-gets($vars, overlay, padding);
+							padding-top: 0;
+						}
 					}
+
 				}
 
 				.upload-overlay .loader{
@@ -28,7 +61,22 @@
 
 				&:hover {
 					.input-overlay {
-						height: map-gets($vars, overlay, height);
+						width: 100%;
+						height: 100%;
+						bottom: 0;
+						right: 0;
+						opacity: .8;
+						> .overlay-content {
+							top: 50%;
+							left: 50%;
+							transform: translate(-50%, -50%);
+							> i {
+								font-size: 1.8em;
+							}
+							> span {
+								display: block;
+							}
+						}
 					}
 				}
 			}

--- a/scss/themes/default/core/elements/_field.defaults.scss
+++ b/scss/themes/default/core/elements/_field.defaults.scss
@@ -123,6 +123,10 @@ $field: (
 			bg-color: 			luiPalette(light, color),
 			height: 			40em,
 		),
+		popover: (
+			bg-color: white,
+			hover-color: luiPalette(light, color, light),
+		),
 		material: (
 			loader-size: 			3em,
 		)

--- a/ts/image-picker/image-picker-popovermenu.html
+++ b/ts/image-picker/image-picker-popovermenu.html
@@ -1,0 +1,8 @@
+<ul class="image-picker-menu">
+	<li class="image-picker-menu-item" ng-click="uploadNewImage($event)">
+		Charger un autre fichier
+	</li>
+	<li class="image-picker-menu-item" ng-click="onDelete()">
+		Supprimer le fichier
+	</li>
+</ul>

--- a/ts/image-picker/image-picker-popovermenu.html
+++ b/ts/image-picker/image-picker-popovermenu.html
@@ -1,8 +1,4 @@
 <ul class="image-picker-menu">
-	<li class="image-picker-menu-item" ng-click="uploadNewImage($event)">
-		Charger un autre fichier
-	</li>
-	<li class="image-picker-menu-item" ng-click="onDelete()">
-		Supprimer le fichier
-	</li>
+	<li class="image-picker-menu-item" ng-click="uploadNewImage($event)" translate="LUIIMGPICKER_MODIFY_IMAGE"></li>
+	<li class="image-picker-menu-item" ng-click="onDelete()" translate="LUIIMGPICKER_DELETE_IMAGE"></li>
 </ul>

--- a/ts/image-picker/image-picker.directive.ts
+++ b/ts/image-picker/image-picker.directive.ts
@@ -115,7 +115,7 @@ module lui.imagepicker {
 			scope.popover = { isOpen: false };
 			scope.togglePopover = ($event: ng.IAngularEvent) => {
 				$event.preventDefault();
-				if (!!this.$scope.file && !!this.deleteEnabled) {
+				if (!!scope.file && !!scope.deleteEnabled) {
 					this.togglePopover($event);
 				} else {
 					this.$scope.uploadNewImage($event);

--- a/ts/image-picker/image-picker.directive.ts
+++ b/ts/image-picker/image-picker.directive.ts
@@ -10,6 +10,7 @@ module lui.imagepicker {
 			croppingRatio: "=",
 			croppingDisabled: "=",
 			deleteEnabled: "=",
+			hideEditHint: "=",
 		};
 		public controller: string = LuidImagePickerController.IID;
 		public static factory(): angular.IDirectiveFactory {

--- a/ts/image-picker/image-picker.directive.ts
+++ b/ts/image-picker/image-picker.directive.ts
@@ -115,7 +115,7 @@ module lui.imagepicker {
 			scope.popover = { isOpen: false };
 			scope.togglePopover = ($event: ng.IAngularEvent) => {
 				$event.preventDefault();
-				if (!this.$scope.file && !this.deleteEnabled) {
+				if (!!this.$scope.file && !!this.deleteEnabled) {
 					this.togglePopover($event);
 				} else {
 					this.$scope.uploadNewImage($event);

--- a/ts/image-picker/image-picker.directive.ts
+++ b/ts/image-picker/image-picker.directive.ts
@@ -54,7 +54,6 @@ module lui.imagepicker {
 		private placeholder: string;
 		private popoverController: popover.IPopoverController;
 		private inputElement: HTMLElement;
-		private deleteEnabled: boolean;
 
 		constructor($scope: IImagepickerScope, uploaderService: IUploaderService, $timeout: ng.ITimeoutService) {
 			this.$scope = $scope;
@@ -112,7 +111,6 @@ module lui.imagepicker {
 				this.closePopover();
 			};
 			this.popoverController = new popover.ClickoutsideTrigger(elt, scope, onClosing);
-			this.deleteEnabled = scope.deleteEnabled || false;
 			scope.popover = { isOpen: false };
 			scope.togglePopover = ($event: ng.IAngularEvent) => {
 				$event.preventDefault();

--- a/ts/image-picker/image-picker.directive.ts
+++ b/ts/image-picker/image-picker.directive.ts
@@ -23,32 +23,50 @@ module lui.imagepicker {
 			let imgPickerCtrl = <LuidImagePickerController>ctrls[1];
 			imgPickerCtrl.setNgModelCtrl(ngModelCtrl);
 			imgPickerCtrl.setPlaceholder(scope.placeholderUrl);
+			imgPickerCtrl.setPopoverTrigger(element, scope);
+			imgPickerCtrl.setElements(element);
 		}
 	}
 
-	interface IImagepickerScope extends ng.IScope {
+	interface IImagepickerScope extends ng.IScope, popover.IClickoutsideTriggerScope {
 		pictureStyle: { "background-image": string };
 		placeholderUrl: string;
 		uploading: boolean;
+		deleteEnabled: boolean;
 		file: any;
 		onCropped(cropped: string): void;
 		onCancelled(): void;
+		onClick(event: ng.IAngularEvent): void;
 		onDelete(): void;
 		setTouched(): void;
+		uploadNewImage($event: ng.IAngularEvent): void;
+		togglePopover($event: ng.IAngularEvent): void;
+		openPopover($event: ng.IAngularEvent): void;
 	}
 
 
 	class LuidImagePickerController {
 		public static IID: string = "luidImagePickerController";
-		public static $inject: Array<string> = ["$scope", "uploaderService"];
+		public static $inject: Array<string> = ["$scope", "uploaderService", "$timeout"];
 		private $scope: IImagepickerScope;
 		private ngModelCtrl: ng.INgModelController;
 		private placeholder: string;
+		private popoverController: popover.IPopoverController;
+		private inputElement: HTMLElement;
+		private deleteEnabled: boolean;
 
-		constructor($scope: IImagepickerScope, uploaderService: IUploaderService) {
+		constructor($scope: IImagepickerScope, uploaderService: IUploaderService, $timeout: ng.ITimeoutService) {
 			this.$scope = $scope;
 			$scope.setTouched = () => {
 				this.ngModelCtrl.$setTouched();
+			};
+
+			$scope.uploadNewImage = ($event: ng.IAngularEvent): void => {
+				// Necessary to wait for a new cycle and avoid $apply issues
+				$timeout(() => {
+					this.inputElement.click();
+					this.closePopover();
+				});
 			};
 			$scope.onCropped = (cropped) => {
 				$scope.uploading = true;
@@ -69,6 +87,7 @@ module lui.imagepicker {
 			$scope.onDelete = () => {
 				this.setViewValue(undefined);
 				this.$scope.pictureStyle = { "background-image": "url('" + this.placeholder + "')" };
+				this.closePopover();
 			};
 		}
 		// set stuff - is called in the linq function
@@ -85,6 +104,46 @@ module lui.imagepicker {
 		}
 		public setPlaceholder(placeholder: string): void {
 			this.placeholder = placeholder || "/static/common/images/placeholder-pp.png";
+		}
+
+		public setPopoverTrigger(elt: angular.IAugmentedJQuery, scope: IImagepickerScope): void {
+			let onClosing = (): void => {
+				this.closePopover();
+			};
+			this.popoverController = new popover.ClickoutsideTrigger(elt, scope, onClosing);
+			this.deleteEnabled = scope.deleteEnabled || false;
+			scope.popover = { isOpen: false };
+			scope.togglePopover = ($event: ng.IAngularEvent) => {
+				$event.preventDefault();
+				if (!this.$scope.file && !this.deleteEnabled) {
+					this.togglePopover($event);
+				} else {
+					this.$scope.uploadNewImage($event);
+				}
+			};
+		}
+
+		public setElements(elt: angular.IAugmentedJQuery): void {
+			this.inputElement = elt.find("input")[0];
+		}
+		private togglePopover($event: ng.IAngularEvent): void {
+			if (this.$scope.popover.isOpen) {
+				this.closePopover();
+			} else {
+				this.openPopover($event);
+			}
+		}
+
+		private closePopover(): void {
+			if (!!this.popoverController) {
+				this.popoverController.close();
+			}
+		}
+
+		private openPopover($event: ng.IAngularEvent): void {
+			if (!!this.popoverController) {
+				this.popoverController.open($event);
+			}
 		}
 
 		private getViewValue(): IFile {

--- a/ts/image-picker/image-picker.html
+++ b/ts/image-picker/image-picker.html
@@ -9,7 +9,7 @@
 	<div class="upload-overlay">
 		<div class="lui inverted loader"></div>
 	</div>
-	<div class="input-overlay">
+	<div class="input-overlay" ng-class="{'hide-editable': hideEditHint}">
 		<div class="overlay-content">
 			<i class="lui icon edit"></i>
 			<span class="lui capitalized sentence" translate="LUIIMGPICKER_UPLOAD_IMAGE"></span>

--- a/ts/image-picker/image-picker.html
+++ b/ts/image-picker/image-picker.html
@@ -1,11 +1,20 @@
-<div class="lui image-picker"  ng-class="{ uploading: uploading }">
+<div class="lui image-picker"  ng-class="{ uploading: uploading }"
+		uib-popover-template="'lui/templates/image-picker/image-picker-popovermenu.html'"
+		popover-trigger="'none'"
+		popover-is-open="popover.isOpen"
+		popover-class="lui luid-image-picker-popup"
+		ng-click="togglePopover($event)">
 	<div class="luid-image-picker-picture" ng-style="pictureStyle"/>
-	<div class="input-overlay">
-		<span class="lui capitalized sentence" translate="LUIIMGPICKER_UPLOAD_IMAGE"></span>
-		<input accept="image/*" type="file" ng-model="file" class="fileInput" file-model="image" luid-image-cropper on-cropped="onCropped" on-cancelled="onCancelled" cropping-disabled="croppingDisabled" cropping-ratio="croppingRatio"/>
-		<i ng-if="deleteEnabled" class="empty" ng-click="onDelete()"></i>
-	</div>
+	<input accept="image/*" type="file" ng-model="file" class="fileInput" file-model="image" luid-image-cropper on-cropped="onCropped" on-cancelled="onCancelled" cropping-disabled="croppingDisabled" cropping-ratio="croppingRatio" onclick="event.stopPropagation()"/>
 	<div class="upload-overlay">
 		<div class="lui inverted loader"></div>
+	</div>
+	<div class="input-overlay">
+		<div class="overlay-content">
+			<i class="lui icon edit"></i>
+			<span class="lui capitalized sentence" translate="LUIIMGPICKER_UPLOAD_IMAGE"></span>
+		</div>
+		<!--  DELETION CASE. CONDITION NEEDS TO BE PUT ELSEWHERE -->
+		<!-- <i ng-if="deleteEnabled" class="empty" ng-click="onDelete()"></i> -->
 	</div>
 </div>

--- a/ts/image-picker/image-picker.translates.ts
+++ b/ts/image-picker/image-picker.translates.ts
@@ -4,6 +4,8 @@ module lui.imagepicker {
 	angular.module("lui.crop").config(["$translateProvider", function ($translateProvider) {
 		$translateProvider.translations("en", {
 			"LUIIMGPICKER_UPLOAD_IMAGE": "change picture",
+			"LUIIMGPICKER_MODIFY_IMAGE": "modify picture",
+			"LUIIMGPICKER_DELETE_IMAGE": "delete picture",
 			"LUIIMGCROPPER_CROP": "Crop",
 			"LUIIMGCROPPER_DO_NOT_CROP": "Do not crop",
 		});
@@ -15,6 +17,8 @@ module lui.imagepicker {
 		});
 		$translateProvider.translations("fr", {
 			"LUIIMGPICKER_UPLOAD_IMAGE": "changer l'image",
+			"LUIIMGPICKER_MODIFY_IMAGE": "modifier l'image",
+			"LUIIMGPICKER_DELETE_IMAGE": "supprimer l'image",
 			"LUIIMGCROPPER_CROP": "Recadrer",
 			"LUIIMGCROPPER_DO_NOT_CROP": "Ne pas recadrer",
 		});


### PR DESCRIPTION
In material design, image picker now shows an edit icon by default. It can be hidden by setting the attribute "hide-edit-hint" to true.
![imagepicker](https://user-images.githubusercontent.com/26228000/27578180-9c3127a8-5b23-11e7-9da1-09194a7833de.gif)

If you have a file uploaded and deleteEnabled is set to true, a popover will show up to let you chose between actions
![imagepicker2](https://user-images.githubusercontent.com/26228000/27578485-89f5dd80-5b24-11e7-9fcb-1a8866265476.gif)
