### PR TITLE
User.picker.fix.call.to.users.api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change log
 
 ## in dev
+### Bug fixes
+- `luid-user-picker` - safe call to `/api/v3/users` when fetching additional properties (for homonyms and bypassed users)
 
 ## 3.1.13 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.13)
 ### Changes (non-breaking)

--- a/demo/lucca/userpicker/userpicker.html
+++ b/demo/lucca/userpicker/userpicker.html
@@ -33,22 +33,22 @@
 	<div class="lui field">
 		<span class="lui compact input">
 			<luid-user-picker ng-if="!!globalConnected"
-			ng-model="firstModel.selected"
-			homonyms-properties="homonymsProperties"
-			show-former-employees="includeFormerEmployees"
-			display-me-first="true"
-			on-select="onSelectFirstModel()"
-			on-remove="onRemoveFirstModel()"
-			custom-filter="customFilter"
-			custom-info="getCustomInfo"
-			custom-info-async="getCustomInfoAsync"
-			control-disabled="disableUserPicker"
-			app-id="appId"
-			operations="operations"
-			bypass-operations-for="bypassOperationsFor">
-		</luid-user-picker>
-		<label>Select a user</label>
-	</span>
+				ng-model="firstModel.selected"
+				homonyms-properties="homonymsProperties"
+				show-former-employees="includeFormerEmployees"
+				display-me-first="true"
+				on-select="onSelectFirstModel()"
+				on-remove="onRemoveFirstModel()"
+				custom-filter="customFilter"
+				custom-info="getCustomInfo"
+				custom-info-async="getCustomInfoAsync"
+				control-disabled="disableUserPicker"
+				app-id="appId"
+				operations="operations"
+				bypass-operations-for="bypassOperationsFor">
+			</luid-user-picker>
+			<label>Select a user</label>
+		</span>
 	</div>
 	<div class="lui dashed divider"></div>
 		<p>

--- a/ts/user-picker/user-picker.service.spec.ts
+++ b/ts/user-picker/user-picker.service.spec.ts
@@ -79,8 +79,8 @@ module lui.userpicker.Test {
 
 		describe("getUserById()", () => {
 			it("should call the right API and return exactly what the API returns", () => {
-				$httpBackend.expectGET(/api\/v3\/users\/42+\?fields=Id,firstName,lastName,dtContractEnd*/i)
-					.respond(200, { data: fakeUser1 });
+				$httpBackend.expectGET(/api\/v3\/users\?id=42\&fields=Id,firstName,lastName,dtContractEnd*/i)
+					.respond(200, { data: { items: [fakeUser1] }});
 				service.getUserById(42).then((user: IUserLookup) => {
 					expect(user.id).toBe(fakeUser1.id);
 				});
@@ -90,12 +90,12 @@ module lui.userpicker.Test {
 
 		describe("getUsersByIds()", () => {
 			it("should call the right API and return exactly what the API returns", () => {
-				$httpBackend.expectGET(/api\/v3\/users\/42\?fields=Id,firstName,lastName,dtContractEnd*/i)
-					.respond(200, { data: fakeUser1 });
-				$httpBackend.expectGET(/api\/v3\/users\/43\?fields=Id,firstName,lastName,dtContractEnd*/i)
-					.respond(200, { data: fakeUser2 });
-				$httpBackend.expectGET(/api\/v3\/users\/44\?fields=Id,firstName,lastName,dtContractEnd*/i)
-					.respond(200, { data: fakeUser3 });
+				$httpBackend.expectGET(/api\/v3\/users\?id=42\&fields=Id,firstName,lastName,dtContractEnd*/i)
+					.respond(200, { data: { items: [fakeUser1] }});
+				$httpBackend.expectGET(/api\/v3\/users\?id=43\&fields=Id,firstName,lastName,dtContractEnd*/i)
+					.respond(200, { data: { items: [fakeUser2] }});
+				$httpBackend.expectGET(/api\/v3\/users\?id=44\&fields=Id,firstName,lastName,dtContractEnd*/i)
+					.respond(200, { data: { items: [fakeUser3] }});
 				service.getUsersByIds([42, 43, 44]).then((users: IUserLookup[]) => {
 					expect(users.length).toBe(3);
 					expect(_.filter(users, (h: IUserLookup) => { return h.id == fakeUser1.id }).length).toBe(1);
@@ -113,8 +113,8 @@ module lui.userpicker.Test {
 					<IHomonymProperty>{ translationKey: "LUIDUSERPICKER_LEGALENTITY", name: "legalEntity.name", icon: "tree list" }
 				];
 
-				$httpBackend.expectGET(/api\/v3\/users\/45\?fields=mail,legalEntity.name*/i)
-					.respond(200, { data: { mail: "fakeuser@gmail.com", legalEntity: { name: "TotoEntity" } } });
+				$httpBackend.expectGET(/api\/v3\/users\?id=45\&fields=mail,legalEntity.name*/i)
+					.respond(200, { data: { items: [{ mail: "fakeuser@gmail.com", legalEntity: { name: "TotoEntity" } }]}});
 
 				service.getAdditionalProperties(fakeUser4, properties)
 					.then((props: IHomonymProperty[]) => {

--- a/ts/user-picker/user-picker.spec.ts
+++ b/ts/user-picker/user-picker.spec.ts
@@ -67,10 +67,10 @@ module lui.userpicker.Test {
 				$httpBackend.expectGET(/api\/v3\/users\/me\?fields=id*/i).respond(200, { data: { id: me.id } });
 				$httpBackend.expectGET(/api\/v3\/users\/find\?.*/i).respond(200, { data: { items: usersWithHomonyms } });
 
-				$httpBackend.expectGET(/api\/v3\/users\/7\?fields=department.name,legalEntity.name,mail.*/i)
-					.respond({ data: { department: { name: "BU" }, legalEntity: { name: "LE" }, mail: "john.doe1@mail.com" } });
-				$httpBackend.expectGET(/api\/v3\/users\/8\?fields=department.name,legalEntity.name,mail.*/i)
-					.respond({ data: { department: { name: "BU" }, legalEntity: { name: "LE" }, mail: "john.doe2@mail.com" } });
+				$httpBackend.expectGET(/api\/v3\/users\?id=7\&fields=department.name,legalEntity.name,mail.*/i)
+					.respond({ data: { items: [{ department: { name: "BU" }, legalEntity: { name: "LE" }, mail: "john.doe1@mail.com" }]}});
+				$httpBackend.expectGET(/api\/v3\/users\?id=8\&fields=department.name,legalEntity.name,mail.*/i)
+					.respond({ data: { items: [{ department: { name: "BU" }, legalEntity: { name: "LE" }, mail: "john.doe2@mail.com" }]}});
 
 				let homonymsCount = service.getHomonyms(usersWithHomonyms).length;
 				spyOn(service, "getAdditionalProperties").and.callThrough();
@@ -84,10 +84,10 @@ module lui.userpicker.Test {
 				$httpBackend.expectGET(/api\/v3\/users\/me\?fields=id*/i).respond(200, { data: { id: me.id } });
 				$httpBackend.expectGET(/api\/v3\/users\/find\?.*/i).respond(200, { data: { items: usersWithHomonyms } });
 
-				$httpBackend.expectGET(/api\/v3\/users\/7\?fields=department.name,legalEntity.name,mail.*/i)
-					.respond({ data: { department: { name: "BU" }, legalEntity: { name: "LE" }, mail: "john.doe1@mail.com" } });
-				$httpBackend.expectGET(/api\/v3\/users\/8\?fields=department.name,legalEntity.name,mail.*/i)
-					.respond({ data: { department: { name: "BU" }, legalEntity: { name: "LE" }, mail: "john.doe2@mail.com" } });
+				$httpBackend.expectGET(/api\/v3\/users\?id=7\&fields=department.name,legalEntity.name,mail.*/i)
+					.respond({ data: { items: [{ department: { name: "BU" }, legalEntity: { name: "LE" }, mail: "john.doe1@mail.com" }]}});
+				$httpBackend.expectGET(/api\/v3\/users\?id=8\&fields=department.name,legalEntity.name,mail.*/i)
+					.respond({ data: { items: [{ department: { name: "BU" }, legalEntity: { name: "LE" }, mail: "john.doe2@mail.com" }]}});
 
 				let homonymsCount = service.getHomonyms(usersWithHomonyms).length;
 				let scope = <ILuidUserPickerScope>$rootScope.$new();
@@ -147,7 +147,7 @@ module lui.userpicker.Test {
 				$httpBackend.expectGET(/api\/v3\/users\/me\?fields=id*/i).respond(200, { data: { id: me.id } });
 				$httpBackend.expectGET(/api\/v3\/users\/find\?.*/i).respond(200, { data: { items: users } });
 
-				$httpBackend.expectGET(/api\/v3\/users\/7\?fields=.*/i).respond(200, { data: user7 });
+				$httpBackend.expectGET(/api\/v3\/users\?id=7\&fields=.*/i).respond(200, { data: { items: [user7] }});
 
 				let scope = <ILuidUserPickerScope>$rootScope.$new();
 				scope.bypassOperationsFor = [7];


### PR DESCRIPTION
Safe call to `/api/v3/users?id={id}` instead of `/api/v3/users/{id}`: happened with homonyms not in your scope (you cannot access their information)