### PR TITLE
User.picker.multiple.fix

### DIFF
--- a/ts/user-picker/user-picker.controller.ts
+++ b/ts/user-picker/user-picker.controller.ts
@@ -187,7 +187,10 @@ module lui.userpicker {
 		}
 
 		private refresh(clue: string = ""): ng.IPromise<any> {
-			return this.getUsers(clue).then(users => this.tidyUpAndAssign(users, clue));
+			return this.getUsers(clue)
+			.then((users: IUserLookup[]) => {
+				this.tidyUpAndAssign(users, clue);
+			});
 		}
 
 		// gets the users according to clue, also adds me and all if needed
@@ -205,7 +208,7 @@ module lui.userpicker {
 
 			let get = () => {
 				return this.userPickerService.getUsers(this.getFilter(clue), fetchPaging, fetchOffset)
-					.then(users => {
+					.then((users: IUserLookup[]) => {
 						if (!!this.$scope.customFilter) {
 							return _.chain(users)
 								.filter(u => this.$scope.customFilter(u))

--- a/ts/user-picker/user-picker.controller.ts
+++ b/ts/user-picker/user-picker.controller.ts
@@ -32,10 +32,7 @@ module lui.userpicker {
 		private $q: ng.IQService;
 		private userPickerService: IUserPickerService;
 
-		private ngModelCtrl: ng.INgModelController;
-
 		/** Indicates if the controller controls a user-picker or a user-picker-multiple directive */
-		private multiple: boolean;
 		private clue: string;
 
 		constructor(
@@ -57,23 +54,6 @@ module lui.userpicker {
 					this.initializeScope();
 				});
 			});
-		}
-
-		public setNgModelCtrl(ngModelCtrl: ng.INgModelController, multiple: boolean = false): void {
-			this.multiple = true;
-			this.ngModelCtrl = ngModelCtrl;
-			ngModelCtrl.$render = () => {
-				if (this.multiple) {
-					this.$scope.selectedUsers = <IUserLookup[]>this.getViewValue();
-				} else {
-					this.$scope.selectedUser = <IUserLookup>this.getViewValue();
-				}
-			};
-		}
-		private getViewValue(): IUserLookup | IUserLookup[] { return this.ngModelCtrl.$viewValue; }
-		private setViewValue(value: IUserLookup | IUserLookup[]): void {
-			this.ngModelCtrl.$setViewValue(angular.copy(value));
-			this.ngModelCtrl.$setTouched();
 		}
 
 		/**
@@ -141,27 +121,6 @@ module lui.userpicker {
 					this.$scope.lastPagingOffset += MAGIC_PAGING;
 					this.$scope.loadingMore = true;
 					this.refresh().then(() => { this.$scope.loadingMore = false; });
-				}
-			};
-
-			this.$scope.onSelectedUserChanged = (user: IUserLookup): void => {
-				this.setViewValue(user);
-				if (!!this.$scope.onSelect()) {
-					this.$scope.onSelect();
-				}
-			};
-
-			this.$scope.onSelectedUsersChanged = (): void => {
-				this.setViewValue(this.$scope.selectedUsers);
-				if (!!this.$scope.onSelect()) {
-					this.$scope.onSelect();
-				}
-			};
-
-			this.$scope.onSelectedUserRemoved = (): void => {
-				this.setViewValue(this.$scope.selectedUsers);
-				if (!!this.$scope.onRemove()) {
-					this.$scope.onRemove();
 				}
 			};
 		}

--- a/ts/user-picker/user-picker.directive.ts
+++ b/ts/user-picker/user-picker.directive.ts
@@ -39,7 +39,6 @@ module lui.userpicker {
 
 			let ngModelCtrl = ctrls[0];
 			let userPickerCtrl = ctrls[1];
-			userPickerCtrl.setNgModelCtrl(ngModelCtrl);
 			scope.onOpen = (isOpen: boolean) => {
 				if (isOpen) {
 					element.addClass("ng-open");

--- a/ts/user-picker/user-picker.directive.ts
+++ b/ts/user-picker/user-picker.directive.ts
@@ -36,9 +36,6 @@ module lui.userpicker {
 			element: angular.IAugmentedJQuery,
 			attrs: angular.IAttributes,
 			ctrls: [ng.INgModelController, LuidUserPickerController]): void {
-
-			let ngModelCtrl = ctrls[0];
-			let userPickerCtrl = ctrls[1];
 			scope.onOpen = (isOpen: boolean) => {
 				if (isOpen) {
 					element.addClass("ng-open");

--- a/ts/user-picker/user-picker.html
+++ b/ts/user-picker/user-picker.html
@@ -1,7 +1,7 @@
 <ui-select
 	ng-disabled="controlDisabled"
 	search-enabled="true"
-	on-select="onSelectedUserChanged($select.selected)"
+	on-select="onSelect()"
 	on-remove="onRemove()"
 	uis-open-close="onOpen(isOpen)"
 	open-on="toggleFormerEmployees">

--- a/ts/user-picker/user-picker.multiple.directive.ts
+++ b/ts/user-picker/user-picker.multiple.directive.ts
@@ -35,9 +35,6 @@ module lui.userpicker {
 			element: angular.IAugmentedJQuery,
 			attrs: angular.IAttributes,
 			ctrls: [ng.INgModelController, LuidUserPickerController]): void {
-
-			let ngModelCtrl = ctrls[0];
-			let userPickerCtrl = ctrls[1];
 			scope.onOpen = (isOpen: boolean) => {
 				if (isOpen) {
 					element.addClass("ng-open");

--- a/ts/user-picker/user-picker.multiple.directive.ts
+++ b/ts/user-picker/user-picker.multiple.directive.ts
@@ -38,7 +38,6 @@ module lui.userpicker {
 
 			let ngModelCtrl = ctrls[0];
 			let userPickerCtrl = ctrls[1];
-			userPickerCtrl.setNgModelCtrl(ngModelCtrl, true);
 			scope.onOpen = (isOpen: boolean) => {
 				if (isOpen) {
 					element.addClass("ng-open");

--- a/ts/user-picker/user-picker.multiple.html
+++ b/ts/user-picker/user-picker.multiple.html
@@ -1,8 +1,8 @@
 <ui-select multiple
 	ng-disabled="controlDisabled"
 	search-enabled="true"
-	on-select="onSelectedUsersChanged()"
-	on-remove="onSelectedUserRemoved()"
+	on-select="onSelect()"
+	on-remove="onRemove()"
 	close-on-select="false"
 	reset-search-input="true"
 	uis-open-close="onOpen(isOpen)"

--- a/ts/user-picker/user-picker.scope.ts
+++ b/ts/user-picker/user-picker.scope.ts
@@ -67,13 +67,8 @@ module lui.userpicker {
 		selectedUser: IUserLookup;
 		loadingMore: boolean;
 		selectedUsers: IUserLookup[];
-		onSelectedUserChanged(user: IUserLookup): void;
 		find(search: string): void;
 		loadMore(): void;
-
-		// Specific to the luid-select-multiple
-		onSelectedUsersChanged(): void;
-		onSelectedUserRemoved(): void;
 		onOpen(isOpen: boolean): void;
 	}
 }

--- a/ts/user-picker/user-picker.service.ts
+++ b/ts/user-picker/user-picker.service.ts
@@ -67,7 +67,10 @@ module lui.userpicker {
 		}
 
 		public getMyId(): ng.IPromise<number> {
-			return this.getMe().then(me => me.id);
+			return this.getMe()
+			.then((me: IUserLookup) => {
+				return me.id;
+			});
 		}
 
 		public getMe(): ng.IPromise<IUserLookup> {
@@ -153,7 +156,7 @@ module lui.userpicker {
 					.flatten()
 					.groupBy((property: IHomonymProperty) => { return property.name; })
 					.value();
-				_.each(groupedProperties, propertyGroup => {
+				_.each(groupedProperties, (propertyGroup: IHomonymProperty[]) => {
 					let uniq = _.uniq(propertyGroup, (property: IHomonymProperty) => { return property.value; });
 					if (uniq.length === 1) {
 						// this property can be removed


### PR DESCRIPTION
`ng-model` not synced for `luid-user-picker-multiple`:
![image](https://user-images.githubusercontent.com/9415349/28662390-4adb989e-72ba-11e7-91da-08321c864439.png)

Since `ui-select` doesn't have its own `ng-model` (it's inherited from `luid-user-picker` directive), we don't need to call `setViewValue()`, it's automatically bound.
Same thing with `ngModelCtrl.$render`: it was never called.