### PR TITLE
[FIX] Error messages positionning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change log
 ## in dev
+### Changes (non-breaking)
+- `input material` - messages are located below the input
 ### Bug fixes
+- `luid-iban` - messages are properly pushed on the right side
+- `luid-iban` - now has a proper size
 
 ## 3.1.17 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.17)
 ### Changes (non-breaking)

--- a/scss/core/elements/_field.scss
+++ b/scss/core/elements/_field.scss
@@ -150,6 +150,12 @@
 			#{$prefix}.field #{$selector}.input {
 				margin-top: 1.3em;
 			}
+			#{$prefix}.field #{$selector}.input {
+				~ .messages, ~ .message {
+					width: 100%;
+					margin-left: 0;
+				}
+			}
 			#{$prefix}.fitting.field #{$selector}.input ~ .messages .message {
 				width: 100% !important;
 			}

--- a/scss/core/elements/input/iban/_input.iban.compact.scss
+++ b/scss/core/elements/input/iban/_input.iban.compact.scss
@@ -4,6 +4,7 @@
 			$selector: lui_input_get_style_selector("compact");
 			#{$prefix}.input#{$selector} {
 				luid-iban {
+					width: auto !important;
 					// Styling
 					// ====
 					> input {

--- a/ts/iban/iban.view.html
+++ b/ts/iban/iban.view.html
@@ -1,3 +1,3 @@
 <input id="countryCode" class="upper-case" type="text" size="2" maxlength="2" ng-model="countryCode" ng-model-options="{ allowInvalid: true }" ng-change="updateValue()" ng-paste="pasteIban($event)" ng-focus="selectInput($event)" luid-select-next ng-blur="setTouched()"/>
 <input id="controlKey" class="upper-case" type="text" size="2" maxlength="2" ng-model="controlKey" ng-model-options="{ allowInvalid: true }" ng-change="updateValue()" luid-select-next ng-blur="setTouched()"luid-keydown mappings="controlKeyMappings"/>
-<input id="bban" class="upper-case" type="text" maxlength="30" ng-model="bban" ng-model-options="{ allowInvalid: true }" ng-change="updateValue()" ng-blur="setTouched()" luid-keydown mappings="bbanMappings"/>
+<input id="bban" class="upper-case" type="text" size="22" maxlength="30" ng-model="bban" ng-model-options="{ allowInvalid: true }" ng-change="updateValue()" ng-blur="setTouched()" luid-keydown mappings="bbanMappings"/>


### PR DESCRIPTION
Error messages goes below input in material mode.
For luid-iban, it is now properly being pushed to its right side in compact mode.