### PR TITLE
[MOD] 'luid-api-select' should allow to hide the clear button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
 ## in dev
+-	'luid-api-select': allows to hide the clear button to avoid empty select match
 ### Bug fixes
 
 ## 3.1.17 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.17)

--- a/demo/lucca/apiselect/apiselect.html
+++ b/demo/lucca/apiselect/apiselect.html
@@ -15,6 +15,7 @@
 		<li><code><b>api</b></code>: the api you wnat to hit</li>
 		<li><code><b>filter</b></code>: a filter you want applied to said api</li>
 		<li><code><b>order-by</b></code>: the order you want applied to the result, must look like <code>name,asc</code> or <code>createdAt,desc</code></li>
+		<li><code><b>allow-clear</b></code>: if not defined or truthy, will allow clearing, if falsy, it won't. It's not supported in 'multiple'</li>
 	</ul>
 </p>
 
@@ -28,9 +29,7 @@
 				ng-model="internal.single"
 				api="api"
 				filter="filter"
-				order="order"
-				disable-clear="false"
-			>
+				order="order">
 			</luid-api-select>
 			<label>single</label>
 		</div>
@@ -41,10 +40,10 @@
 	<div class="lui long field">
 		<div class="lui compact input">
 			<luid-api-select-multiple ng-if="!!globalConnected"
-			ng-model="internal.multiple"
-			api="api"
-			filter="filter"
-			order-by="order">
+				ng-model="internal.multiple"
+				api="api"
+				filter="filter"
+				order-by="order">
 			</luid-api-select-multiple>
 			<label>multiple</label>
 		</div>

--- a/demo/lucca/apiselect/apiselect.html
+++ b/demo/lucca/apiselect/apiselect.html
@@ -15,7 +15,7 @@
 		<li><code><b>api</b></code>: the api you wnat to hit</li>
 		<li><code><b>filter</b></code>: a filter you want applied to said api</li>
 		<li><code><b>order-by</b></code>: the order you want applied to the result, must look like <code>name,asc</code> or <code>createdAt,desc</code></li>
-		<li><code><b>allow-clear</b></code>: if not defined or truthy, will allow clearing, if falsy, it won't. It's not supported in 'multiple'</li>
+		<li><code><b>allow-clear</b></code>: allows you to clear the current value. It's not supported in 'multiple'</li>
 	</ul>
 </p>
 
@@ -29,7 +29,8 @@
 				ng-model="internal.single"
 				api="api"
 				filter="filter"
-				order="order">
+				order="order"
+				allow-clear="false">
 			</luid-api-select>
 			<label>single</label>
 		</div>

--- a/demo/lucca/apiselect/apiselect.html
+++ b/demo/lucca/apiselect/apiselect.html
@@ -25,10 +25,11 @@
 	<div class="lui field">
 		<div class="lui compact long input">
 			<luid-api-select ng-if="!!globalConnected"
-			ng-model="internal.single"
-			api="api"
-			filter="filter"
-			order="order"
+				ng-model="internal.single"
+				api="api"
+				filter="filter"
+				order="order"
+				disable-clear="false"
 			>
 			</luid-api-select>
 			<label>single</label>

--- a/ts/formly/fields/api-select-multiple.html
+++ b/ts/formly/fields/api-select-multiple.html
@@ -1,6 +1,6 @@
 <div class="lui {{::options.templateOptions.display}} field">
 	<div class="lui {{::options.templateOptions.style}} input">
-		<luid-api-select-multiple api="options.templateOptions.api" filter="options.templateOptions.filter" placeholder="{{::options.templateOptions.placeholder}}" name="{{::id}}" ng-model="model[options.key]" ng-required="{{::options.templateOptions.required}}"></luid-api-select-multiple>
+		<luid-api-select-multiple api="options.templateOptions.api" allow-clear="options.templateOptions.allowClear" filter="options.templateOptions.filter" placeholder="{{::options.templateOptions.placeholder}}" name="{{::id}}" ng-model="model[options.key]" ng-required="{{::options.templateOptions.required}}"></luid-api-select-multiple>
 		<label for="{{::id}}">{{ options.templateOptions.label }}</label>
 	</div>
 	<small class="message helper">{{ options.templateOptions.helper }}</small>

--- a/ts/formly/fields/api-select-multiple.html
+++ b/ts/formly/fields/api-select-multiple.html
@@ -1,6 +1,6 @@
 <div class="lui {{::options.templateOptions.display}} field">
 	<div class="lui {{::options.templateOptions.style}} input">
-		<luid-api-select-multiple api="options.templateOptions.api" allow-clear="options.templateOptions.allowClear" filter="options.templateOptions.filter" placeholder="{{::options.templateOptions.placeholder}}" name="{{::id}}" ng-model="model[options.key]" ng-required="{{::options.templateOptions.required}}"></luid-api-select-multiple>
+		<luid-api-select-multiple api="options.templateOptions.api" filter="options.templateOptions.filter" placeholder="{{::options.templateOptions.placeholder}}" name="{{::id}}" ng-model="model[options.key]" ng-required="{{::options.templateOptions.required}}"></luid-api-select-multiple>
 		<label for="{{::id}}">{{ options.templateOptions.label }}</label>
 	</div>
 	<small class="message helper">{{ options.templateOptions.helper }}</small>

--- a/ts/formly/fields/api-select.html
+++ b/ts/formly/fields/api-select.html
@@ -1,6 +1,6 @@
 <div class="lui {{::options.templateOptions.display}} field">
 	<div class="lui {{::options.templateOptions.style}} input">
-		<luid-api-select api="options.templateOptions.api" disable-clear="options.templateOptions.disableClear" filter="options.templateOptions.filter" placeholder="{{::options.templateOptions.placeholder}}" name="{{::id}}" ng-model="model[options.key]" ng-required="{{::options.templateOptions.required}}"></luid-api-select>
+		<luid-api-select api="options.templateOptions.api" allow-clear="options.templateOptions.allowClear" filter="options.templateOptions.filter" placeholder="{{::options.templateOptions.placeholder}}" name="{{::id}}" ng-model="model[options.key]" ng-required="{{::options.templateOptions.required}}"></luid-api-select>
 		<label for="{{::id}}">{{ options.templateOptions.label }}</label>
 	</div>
 	<small class="message helper">{{ options.templateOptions.helper }}</small>

--- a/ts/formly/fields/api-select.html
+++ b/ts/formly/fields/api-select.html
@@ -1,6 +1,6 @@
 <div class="lui {{::options.templateOptions.display}} field">
 	<div class="lui {{::options.templateOptions.style}} input">
-		<luid-api-select api="options.templateOptions.api" filter="options.templateOptions.filter" placeholder="{{::options.templateOptions.placeholder}}" name="{{::id}}" ng-model="model[options.key]" ng-required="{{::options.templateOptions.required}}"></luid-api-select>
+		<luid-api-select api="options.templateOptions.api" disable-clear="options.templateOptions.disableClear" filter="options.templateOptions.filter" placeholder="{{::options.templateOptions.placeholder}}" name="{{::id}}" ng-model="model[options.key]" ng-required="{{::options.templateOptions.required}}"></luid-api-select>
 		<label for="{{::id}}">{{ options.templateOptions.label }}</label>
 	</div>
 	<small class="message helper">{{ options.templateOptions.helper }}</small>

--- a/ts/formly/formly.class.ts
+++ b/ts/formly/formly.class.ts
@@ -27,5 +27,6 @@ module lui {
 		// api-select field type
 		api?: string;
 		filter?: string;
+		disableClear?: boolean;
 	}
 }

--- a/ts/formly/formly.class.ts
+++ b/ts/formly/formly.class.ts
@@ -27,6 +27,6 @@ module lui {
 		// api-select field type
 		api?: string;
 		filter?: string;
-		disableClear?: boolean;
+		allowClear?: boolean;
 	}
 }

--- a/ts/formly/inputs/api-select-multiple.html
+++ b/ts/formly/inputs/api-select-multiple.html
@@ -1,5 +1,5 @@
 <ui-select multiple>
-	<ui-select-match placeholder="{{::placeholder}}" allow-clear="true">{{$item.name}}</ui-select-match>
+	<ui-select-match placeholder="{{::placeholder}}" allow-clear="{{allowClear}}">{{$item.name}}</ui-select-match>
 	<ui-select-choices repeat="choice in choices track by choice.id" refresh="refresh($select.search)" refresh-delay="0" luid-on-scroll-bottom="loadMore($select.search)">
 	<div ng-bind-html="choice.name | highlight: $select.search"></div>
 	</ui-select-choices>

--- a/ts/formly/inputs/api-select-multiple.html
+++ b/ts/formly/inputs/api-select-multiple.html
@@ -1,5 +1,5 @@
 <ui-select multiple>
-	<ui-select-match placeholder="{{::placeholder}}" allow-clear="{{allowClear}}">{{$item.name}}</ui-select-match>
+	<ui-select-match placeholder="{{::placeholder}}">{{$item.name}}</ui-select-match>
 	<ui-select-choices repeat="choice in choices track by choice.id" refresh="refresh($select.search)" refresh-delay="0" luid-on-scroll-bottom="loadMore($select.search)">
 	<div ng-bind-html="choice.name | highlight: $select.search"></div>
 	</ui-select-choices>

--- a/ts/formly/inputs/api-select.directive.ts
+++ b/ts/formly/inputs/api-select.directive.ts
@@ -10,7 +10,7 @@ module lui.apiselect {
 			filter: "=",
 			orderBy: "=",
 			placeholder: "@",
-			disableClear: "="
+			allowClear: "=?"
 		};
 		public controller = ApiSelectController.IID;
 
@@ -21,7 +21,10 @@ module lui.apiselect {
 			return directive;
 		}
 
-		public link(scope: IApiSelectScope, element: angular.IAugmentedJQuery): void {
+		public link(scope: IApiSelectScope, element: angular.IAugmentedJQuery, attrs: angular.IAttributes & {allowClear: boolean}): void {
+			let allowClear = attrs.allowClear;
+			if (allowClear === undefined) { allowClear = true; }
+
 			scope.onDropdownToggle = (isOpen: boolean) => {
 				if (isOpen) {
 					element.addClass("ng-open");
@@ -40,6 +43,7 @@ module lui.apiselect {
 			filter: "=",
 			orderBy: "=",
 			placeholder: "@",
+			allowClear: "=?"
 		};
 		public controller = ApiSelectController.IID;
 
@@ -49,7 +53,11 @@ module lui.apiselect {
 			};
 			return directive;
 		}
-		public link(scope: IApiSelectScope, element: angular.IAugmentedJQuery): void {
+
+		public link(scope: IApiSelectScope, element: angular.IAugmentedJQuery, attrs: angular.IAttributes & { allowClear: boolean }): void {
+			let allowClear = attrs.allowClear;
+			if (allowClear === undefined) { allowClear = true; }
+
 			scope.onDropdownToggle = (isOpen: boolean) => {
 				if (isOpen) {
 					element.addClass("ng-open");

--- a/ts/formly/inputs/api-select.directive.ts
+++ b/ts/formly/inputs/api-select.directive.ts
@@ -10,6 +10,7 @@ module lui.apiselect {
 			filter: "=",
 			orderBy: "=",
 			placeholder: "@",
+			disableClear: "="
 		};
 		public controller = ApiSelectController.IID;
 

--- a/ts/formly/inputs/api-select.directive.ts
+++ b/ts/formly/inputs/api-select.directive.ts
@@ -10,7 +10,7 @@ module lui.apiselect {
 			filter: "=",
 			orderBy: "=",
 			placeholder: "@",
-			allowClear: "=?"
+			allowClear: "="
 		};
 		public controller = ApiSelectController.IID;
 
@@ -21,10 +21,7 @@ module lui.apiselect {
 			return directive;
 		}
 
-		public link(scope: IApiSelectScope, element: angular.IAugmentedJQuery, attrs: angular.IAttributes & {allowClear: boolean}): void {
-			let allowClear = attrs.allowClear;
-			if (allowClear === undefined) { allowClear = true; }
-
+		public link(scope: IApiSelectScope, element: angular.IAugmentedJQuery): void {
 			scope.onDropdownToggle = (isOpen: boolean) => {
 				if (isOpen) {
 					element.addClass("ng-open");

--- a/ts/formly/inputs/api-select.directive.ts
+++ b/ts/formly/inputs/api-select.directive.ts
@@ -42,8 +42,7 @@ module lui.apiselect {
 			api: "=",
 			filter: "=",
 			orderBy: "=",
-			placeholder: "@",
-			allowClear: "=?"
+			placeholder: "@"
 		};
 		public controller = ApiSelectController.IID;
 
@@ -54,10 +53,7 @@ module lui.apiselect {
 			return directive;
 		}
 
-		public link(scope: IApiSelectScope, element: angular.IAugmentedJQuery, attrs: angular.IAttributes & { allowClear: boolean }): void {
-			let allowClear = attrs.allowClear;
-			if (allowClear === undefined) { allowClear = true; }
-
+		public link(scope: IApiSelectScope, element: angular.IAugmentedJQuery): void {
 			scope.onDropdownToggle = (isOpen: boolean) => {
 				if (isOpen) {
 					element.addClass("ng-open");

--- a/ts/formly/inputs/api-select.html
+++ b/ts/formly/inputs/api-select.html
@@ -1,5 +1,5 @@
 <ui-select uis-open-close="onDropdownToggle(isOpen)">
-	<ui-select-match placeholder="{{::placeholder}}" allow-clear="true">{{$select.selected.name}}</ui-select-match>
+	<ui-select-match placeholder="{{::placeholder}}" allow-clear="{{!disableClear}}">{{$select.selected.name}}</ui-select-match>
 	<ui-select-choices repeat="choice in choices track by choice.id" refresh="refresh($select.search)" refresh-delay="0" luid-on-scroll-bottom="loadMore($select.search)">
 		<div ng-bind-html="choice.name | highlight: $select.search" ng-hide="$last &&!!choice.loading"></div>
 		<div ng-show="$last &&!!choice.loading" class="lui loader"></div>

--- a/ts/formly/inputs/api-select.html
+++ b/ts/formly/inputs/api-select.html
@@ -1,5 +1,5 @@
 <ui-select uis-open-close="onDropdownToggle(isOpen)">
-	<ui-select-match placeholder="{{::placeholder}}" allow-clear="{{!disableClear}}">{{$select.selected.name}}</ui-select-match>
+	<ui-select-match placeholder="{{::placeholder}}" allow-clear="{{allowClear}}">{{$select.selected.name}}</ui-select-match>
 	<ui-select-choices repeat="choice in choices track by choice.id" refresh="refresh($select.search)" refresh-delay="0" luid-on-scroll-bottom="loadMore($select.search)">
 		<div ng-bind-html="choice.name | highlight: $select.search" ng-hide="$last &&!!choice.loading"></div>
 		<div ng-show="$last &&!!choice.loading" class="lui loader"></div>


### PR DESCRIPTION
Sometimes we need to avoid the empty button in a field, for example, during the selection of the Language in 'My Account', hence the necessity to add a parameter **disableClear** in ApiSelect Directive, which does not alter the previous usage of this directive and enables this new feature.