### PR TITLE
Iban.maxlength.error LD-686

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## in dev
 ### Changes (non-breaking)
 ### Bug fixes
+- `luid-iban` - add error when iban is initially too long
 
 ## 3.1.22 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.22)
 ### Bug fixes
-- `lud-moment`- moment-picker with min and max hours
+- `luid-moment`- moment-picker with min and max hours
 
 ## 3.1.21 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/3.1.21)
 ### Bug fixes

--- a/ts/formly/fields/iban.html
+++ b/ts/formly/fields/iban.html
@@ -5,5 +5,8 @@
 	</div>
 	<small class="message helper">{{ options.templateOptions.helper }}</small>
 	<small class="message error lui animated up fade in" ng-show="form.{{::id}}.$dirty && form.{{::id}}.$error.required">{{::options.templateOptions.requiredError}}</small>
-	<small class="message error lui animated up fade in" ng-show="form.{{::id}}.$dirty && form.{{::id}}.$error.iban">{{::options.templateOptions.ibanError}}</small>
+	<small class="message error lui animated up fade in"
+		   ng-show="form.{{::id}}.$dirty && (form.{{::id}}.$error.iban || form.{{::id}}.$error.maxlength)">
+		   {{::options.templateOptions.ibanError}}
+	</small>
 </div>

--- a/ts/iban/iban.controller.ts
+++ b/ts/iban/iban.controller.ts
@@ -25,7 +25,7 @@ module lui.iban {
 		public setNgModelCtrl(ngModelCtrl: ng.INgModelController): void {
 			this.ngModelCtrl = ngModelCtrl;
 			this.ngModelCtrl.$render = (): void => {
-				let iban = this.getViewValue() ? this.getViewValue().replace(" ", "") : null ;
+				let iban = this.getViewValue() ? this.getViewValue().replace(" ", "") : null;
 				if (!!iban) {
 					this.$scope.countryCode = iban.substring(0, 2);
 					this.$scope.controlKey = iban.substring(2, 4);
@@ -39,6 +39,12 @@ module lui.iban {
 			(<ILuidIbanValidators>this.ngModelCtrl.$validators).iban = (): boolean => {
 				if (!!this.ngModelCtrl.$viewValue) {
 					return this.ibanChecker.isValid(ngModelCtrl.$viewValue);
+				}
+				return true;
+			};
+			(<ILuidIbanValidators>this.ngModelCtrl.$validators).maxlength = (): boolean => {
+				if (!!this.ngModelCtrl.$viewValue) {
+					return this.ngModelCtrl.$viewValue.length <= 34;
 				}
 				return true;
 			};

--- a/ts/iban/iban.validator.ts
+++ b/ts/iban/iban.validator.ts
@@ -3,5 +3,6 @@ module lui.iban {
 
 	export interface ILuidIbanValidators extends ng.IModelValidators {
 		iban: () => boolean;
+		maxlength: () => boolean;
 	}
 }


### PR DESCRIPTION
Adds an error when the IBAN is initially too long [(LD-686](https://luccasoftware.atlassian.net/browse/LD-686))

To test it, update the file `/demo/directives/iban.js` and add a lot of spaces to the `$scope.iban` variable : 

``` js
$scope.iban = "FR76300040000                  31234567890143";
```

The `luid-iban` directive used on the page `http://localhost:12345/demo/#/directives#luid-iban` should be red

![image](https://user-images.githubusercontent.com/8553617/35856208-95a2c9ba-0b35-11e8-8182-9fffa350f628.png)
