### PR TITLE
[FIX][SCSS] Sass build was breaking when prefix was empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Breaking Changes
 ### Changes (non-breaking)
 ### Bug fixes
-
+The SASS build was breaking when `$prefix` was empty.
 
 ## 4.0.2 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/4.0.2)
 ### Breaking Changes

--- a/scss/core/elements/input/dropdown/_input.dropdown.compact.scss
+++ b/scss/core/elements/input/dropdown/_input.dropdown.compact.scss
@@ -18,15 +18,11 @@
 	@at-root #{$namespace} {
 		@if lui_input_style_enabled("compact") {
 			$selector: lui_input_get_style_selector("compact");
-			#{$prefix}#{$selector} {
-
-				&.dropdown .dropdown-header {
-					@extend %lui_dropdown_list_group_header_compact;
-				}
-
-				&[uib-dropdown] ul li {
-					@extend %lui_dropdown_list_item_compact;
-				}
+			#{$prefix}#{$selector}.dropdown .dropdown-header {
+				@extend %lui_dropdown_list_group_header_compact;
+			}
+			#{$prefix}#{$selector}[uib-dropdown] ul li {
+				@extend %lui_dropdown_list_item_compact;
 			}
 		}
 	}

--- a/scss/core/elements/input/dropdown/_input.dropdown.material.scss
+++ b/scss/core/elements/input/dropdown/_input.dropdown.material.scss
@@ -18,15 +18,11 @@
 	@at-root #{$namespace} {
 		@if lui_input_style_enabled("material") {
 			$selector: lui_input_get_style_selector("material");
-			#{$prefix}#{$selector} {
-
-				&.dropdown .dropdown-header {
-					@extend %lui_dropdown_list_group_header_material;
-				}
-
-				&[uib-dropdown] ul li {
-					@extend %lui_dropdown_list_item_material;
-				}
+			#{$prefix}#{$selector}.dropdown .dropdown-header {
+				@extend %lui_dropdown_list_group_header_material;
+			}
+			#{$prefix}#{$selector}[uib-dropdown] ul li {
+				@extend %lui_dropdown_list_item_material;
 			}
 		}
 	}


### PR DESCRIPTION
When `$prefix` is empty, there were possibly 2 selectors that ended up empty which led to an error with node-sass. 