### PR TITLE
select multiple [fix] arrow icon should not block select opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 ### Changes (non-breaking)
 ### Bug fixes
+- `ui-select-multiple` arrow icon don't block the click interaction anymore.
 
 ## 4.1.1 - [release](https://github.com/LuccaSA/lucca-ui/releases/tag/4.1.1)
 ### Breaking Changes

--- a/scss/core/elements/input/ui-select/_input.ui-select.common.scss
+++ b/scss/core/elements/input/ui-select/_input.ui-select.common.scss
@@ -64,9 +64,10 @@
 			&:not(.open) .ui-select-toggle,
 			&.ui-select-multiple:not(.open) > div {
 				@include lui_make_icon('south chevron', right);
-				&:after {
+				&::after {
 					@extend %lui_field_input_inner_right_icon;
 					font-size: 8px;
+					pointer-events: none;
 				}
 			}
 


### PR DESCRIPTION
Arrow icon on select multiple was blocking the click interaction