### PR TITLE
Remove broken badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Stories in Ready](https://badge.waffle.io/LuccaSA/lucca-ui.png?label=ready&title=Ready)](https://waffle.io/LuccaSA/lucca-ui)
-[![Build Status](https://travis-ci.org/LuccaSA/lucca-ui.svg?branch=master)](https://travis-ci.org/LuccaSA/lucca-ui)
-[![Dependency Status](https://dependencyci.com/github/LuccaSA/lucca-ui/badge)](https://dependencyci.com/github/LuccaSA/lucca-ui)
 # Lucca-ui
 Framework Sass &amp; Angular by Lucca
 [luccaSA.github.io/lucca-ui](http://luccaSA.github.io/lucca-ui)


### PR DESCRIPTION
<https://waffle.io/> and <https://dependencyci.com/> are no longer available.

travis-ci.org is still alive but the badge is broken (https://travis-ci.org/LuccaSA/lucca-ui.svg?branch=master), so can probably be fixed instead of removed if you want to keep it.