### PR TITLE
chore: fix NodeJS security issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 Framework Sass &amp; Angular by Lucca
 [luccaSA.github.io/lucca-ui](http://luccaSA.github.io/lucca-ui)
 
+> ⚠️ This repository is not maintained anymore and will be archived in a near future.
+
+
 # Version 4.x
 
 ## How to install

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "build": "grunt dist"
   },
   "volta": {
-    "node": "8.17.0",
+    "node": "24.13.0",
     "yarn": "1.21.1"
   }
 }


### PR DESCRIPTION
## Description

This PR updates the Node.js version go back on track for projects using unsuppored NodeJS versions.

LTS versions of NodeJS are the last three even versions (20, 22 and 24 as of today).
The "current" version is supported as well (ie 25 as of today).

As we use NodeJS only on local and CI side, no need to deploy this pull request once merged.

If this PR builds, it should be good to merge.

-----

## Checklist

- [x] Bump NodeJS to latest LTS version
- [ ] Check that project build
